### PR TITLE
Add custom recurrence pattern type to CalendarEvent

### DIFF
--- a/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
+++ b/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
@@ -185,6 +185,11 @@
                       "enumValue": "relativeYearly",
                       "name": "relativeYearly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:relativeYearly;1"
+                    },
+                    {
+                      "enumValue": "custom",
+                      "name": "custom",
+                      "@id": "dtmi:com:syyclops:CalendarEvent:custom;1"
                     }
                   ],
                   "valueSchema": "string",


### PR DESCRIPTION
## Summary
- Adds `custom` enum value to the `RecurrencePattern` type in `CalendarEvent.json`
- Supports custom recurrence schedules beyond standard daily/weekly/monthly/yearly patterns

## Test plan
- [ ] Run ontology generation in the main repo to verify the new enum value is picked up