### PR TITLE
Added custom customOccurrenceDates to Calendar Event

### DIFF
--- a/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
+++ b/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
@@ -193,7 +193,7 @@
                     }
                   ],
                   "valueSchema": "string",
-                  "@id": "dtmi:com:syyclops:RecurrencePatternType;1"
+                  "@id": "dtmi:com:syyclops:CalendarEvent:PatternedRecurrence;1"
                 },
                 "@id": "dtmi:com:syyclops:CalendarEvent:type;1"
               },
@@ -282,7 +282,7 @@
                     }
                   ],
                   "valueSchema": "string",
-                  "@id": "dtmi:com:syyclops:RecurrenceRangeType;1"
+                  "@id": "dtmi:com:syyclops:CalendarEvent:ES2;1"
                 },
                 "@id": "dtmi:com:syyclops:CalendarEvent:OF1;1"
               },

--- a/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
+++ b/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
@@ -193,7 +193,7 @@
                     }
                   ],
                   "valueSchema": "string",
-                  "@id": "dtmi:com:syyclops:CalendarEvent:PatternedRecurrence;1"
+                  "@id": "dtmi:com:syyclops:RecurrencePatternType;1"
                 },
                 "@id": "dtmi:com:syyclops:CalendarEvent:type;1"
               },
@@ -282,7 +282,7 @@
                     }
                   ],
                   "valueSchema": "string",
-                  "@id": "dtmi:com:syyclops:CalendarEvent:ES2;1"
+                  "@id": "dtmi:com:syyclops:RecurrenceRangeType;1"
                 },
                 "@id": "dtmi:com:syyclops:CalendarEvent:OF1;1"
               },

--- a/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
+++ b/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
@@ -316,6 +316,21 @@
             }
           },
           "@id": "dtmi:com:syyclops:CalendarEvent:range;1"
+        },
+        {
+          "name": "customOccurrenceDates",
+          "displayName": {
+            "en": "Custom Occurrence Dates"
+          },
+          "description": {
+            "en": "An array of specific dates for custom recurrence patterns that do not follow a regular cadence."
+          },
+          "schema": {
+            "@type": "Array",
+            "elementSchema": "dateTime",
+            "@id": "dtmi:com:syyclops:PatternedRecurrence:customOccurrenceDatesArray;1"
+          },
+          "@id": "dtmi:com:syyclops:PatternedRecurrence:customOccurrenceDates;1"
         }
       ],
       "displayName": {


### PR DESCRIPTION
## Summary
- Adds a new `customOccurrenceDates` property to the `PatternedRecurrence` component on CalendarEvent
- Field is an `Array` of `dateTime`, used to capture specific dates for custom recurrence patterns that don't follow a regular cadence

## Test plan
- [ ] Validate CalendarEvent.json parses as a valid DTDL model
- [ ] Run ontology codegen and confirm `customOccurrenceDates` surfaces on the generated CalendarEvent type