### PR TITLE
Add Video interface under Document

### DIFF
--- a/Ontology/Syyclops/Document/Video.json
+++ b/Ontology/Syyclops/Document/Video.json
@@ -1,0 +1,17 @@
+{
+  "@id": "dtmi:com:syyclops:Video;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Video"
+  },
+  "extends": [
+    "dtmi:com:syyclops:Document;1"
+  ],
+  "contents": [],
+  "@context": [
+    "dtmi:dtdl:context;3"
+  ],
+  "description": {
+    "en": "The Video interface represents moving-image media associated with the document, such as recordings of equipment, sites, or work performed."
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new `Video` interface (`dtmi:com:syyclops:Video;1`) extending `Document`, as a sibling of `Image`.

## Why

The mobile app is gaining the ability to capture videos against work orders (alongside the existing photo capture). We need an ontology type to represent video media so video files can be attached to twins (work orders, assets, spaces, etc.) the same way images already are.

## Modeling decision

`Video` extends `Document` directly — peer to `Image`:

- `Image` is scoped to still imagery ("photos or diagrams")
- `Video` covers moving-image media (recordings of equipment, sites, work performed)
- Both inherit the shared file metadata from `Document` (`url`, `filename`, `fileSize`, `hashMD5`, `mimeType`-style fields, `createdBy`, etc.)

Keeping them as siblings preserves the meaning of `Image` for consumers that filter on it (e.g. photo galleries) and avoids stretching `Image` to cover something it wasn't intended for.

## Files changed

- `Ontology/Syyclops/Document/Video.json` — new interface

## Out of scope

- A future `Media` parent (`Image extends Media`, `Video extends Media`) could simplify "any media" queries, but that's a refactor of the existing `Image` lineage and isn't required for this addition.