### PR TITLE
feat: add netArea, wall boundaries and boundedBy to Space ontology

### DIFF
--- a/Ontology/Syyclops/Component/Space/SpaceArea.json
+++ b/Ontology/Syyclops/Component/Space/SpaceArea.json
@@ -115,6 +115,42 @@
       "description": {
         "en": "Indicates the unit of measurement for the rentable area."
       }
+    },
+    {
+      "@type": [
+        "Property",
+        "Area"
+      ],
+      "name": "netArea",
+      "displayName": {
+        "en": "Net Area"
+      },
+      "writable": true,
+      "schema": "double",
+      "unit": "squareMetre",
+      "@id": "dtmi:com:syyclops:SpaceArea:netArea;1",
+      "description": {
+        "en": "Represents the net area of the space, measured from the inside faces of its bounding walls (COBie.Space.NetArea)."
+      }
+    },
+    {
+      "@type": [
+        "Property",
+        "ValueAnnotation",
+        "Override"
+      ],
+      "displayName": {
+        "en": "Net Area Unit"
+      },
+      "name": "netAreaUnit",
+      "annotates": "netArea",
+      "overrides": "unit",
+      "schema": "AreaUnit",
+      "writable": true,
+      "@id": "dtmi:com:syyclops:SpaceArea:netAreaUnit;1",
+      "description": {
+        "en": "Specifies the unit of measurement for the net area."
+      }
     }
   ],
   "@context": [

--- a/Ontology/Syyclops/Component/Space/SpaceBoundaries.json
+++ b/Ontology/Syyclops/Component/Space/SpaceBoundaries.json
@@ -1,0 +1,93 @@
+{
+  "@id": "dtmi:com:syyclops:SpaceBoundaries;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Space Boundaries"
+  },
+  "extends": [
+    "dtmi:com:syyclops:SpaceComponent;1"
+  ],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "walls",
+      "displayName": {
+        "en": "Walls"
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Array",
+        "@id": "dtmi:com:syyclops:SpaceBoundaries:AS1;1",
+        "elementSchema": {
+          "@type": "Object",
+          "@id": "dtmi:com:syyclops:SpaceBoundaries:OS2;1",
+          "fields": [
+            {
+              "name": "name",
+              "displayName": {
+                "en": "Wall Name"
+              },
+              "schema": "string",
+              "@id": "dtmi:com:syyclops:SpaceBoundaries:wallName;1",
+              "description": {
+                "en": "Label of the bounding wall relative to this space, e.g. its orientation (North, South/East)."
+              }
+            },
+            {
+              "name": "geometryExternalID",
+              "displayName": {
+                "en": "Geometry External ID"
+              },
+              "schema": "string",
+              "@id": "dtmi:com:syyclops:SpaceBoundaries:wallGeometryExternalID;1",
+              "description": {
+                "en": "Reference to the wall in the geometry source (i.e. Revit GUID), used to resolve the corresponding Wall twin."
+              }
+            },
+            {
+              "name": "area",
+              "displayName": {
+                "en": "Wall Area"
+              },
+              "schema": "double",
+              "@id": "dtmi:com:syyclops:SpaceBoundaries:wallArea;1",
+              "description": {
+                "en": "Surface area that this wall contributes to the space (COBie.Space.Walls)."
+              }
+            }
+          ]
+        }
+      },
+      "@id": "dtmi:com:syyclops:SpaceBoundaries:walls;1",
+      "description": {
+        "en": "The walls bounding this space and the surface area each contributes to it. A wall shared by several spaces appears in each space's list with its space-specific area (COBie.Space.Walls)."
+      }
+    },
+    {
+      "@type": [
+        "Property",
+        "ValueAnnotation"
+      ],
+      "name": "wallsAreaUnit",
+      "displayName": {
+        "en": "Walls Area Unit"
+      },
+      "annotates": "walls",
+      "writable": true,
+      "schema": "string",
+      "@id": "dtmi:com:syyclops:SpaceBoundaries:wallsAreaUnit;1",
+      "description": {
+        "en": "Specifies the unit of measurement for the wall areas."
+      }
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
+  ],
+  "description": {
+    "en": "Defines an interface encapsulating the physical boundaries of a space, as derived from the design model."
+  }
+}

--- a/Ontology/Syyclops/Space/Space.json
+++ b/Ontology/Syyclops/Space/Space.json
@@ -60,6 +60,18 @@
     {
       "@type": "Relationship",
       "description": {
+        "en": "The walls (or other building elements) that physically delimit this space. A shared wall bounds each of the spaces it separates."
+      },
+      "displayName": {
+        "en": "bounded by"
+      },
+      "name": "boundedBy",
+      "target": "dtmi:com:syyclops:Wall;1",
+      "@id": "dtmi:com:syyclops:Space:boundedBy;1"
+    },
+    {
+      "@type": "Relationship",
+      "description": {
         "en": "Property that defines the legal owner(s) of a given entity. Inverse of: owns"
       },
       "displayName": {
@@ -309,6 +321,18 @@
       "@id": "dtmi:com:syyclops:Space:area;1",
       "description": {
         "en": "Component representing the area of the space."
+      }
+    },
+    {
+      "@type": "Component",
+      "name": "boundaries",
+      "displayName": {
+        "en": "Boundaries"
+      },
+      "schema": "dtmi:com:syyclops:SpaceBoundaries;1",
+      "@id": "dtmi:com:syyclops:Space:boundaries;1",
+      "description": {
+        "en": "Component representing the physical boundaries of the space, such as its bounding walls and their surface areas."
       }
     },
     {


### PR DESCRIPTION
## What

Adds the DTDL definitions needed to capture COBie space data on rooms.

**Consumed by:** syyclops/syyclops-v3#2311 (issue syyclops/syyclops-v3#2230) — bumps the submodule pointer to this branch and regenerates the ontology-sdk TypeScript from these files.

- **`SpaceArea`** — adds `netArea` + `netAreaUnit` (COBie.Space.NetArea), following the existing `grossArea`/`usableArea` pattern.
- **`SpaceBoundaries`** (new component interface) — `walls`, an array of `{ name, geometryExternalID, area }` describing the walls bounding a space and the surface each contributes to it, plus `wallsAreaUnit`. A wall shared by several spaces appears in each space's list with its space-specific area (COBie.Space.Walls).
- **`Space`** — adds the `boundaries` component and a `boundedBy` relationship to `Wall`.

## Why

A wall is usually shared between several rooms, so its per-room surface cannot live on the Wall twin. The per-room view lives on the Space via the `boundaries` component (same family as `area`, `occupancy`). The Wall twin stays the single canonical entity; `boundedBy` makes the room/wall graph queryable.

## Notes

- No breaking changes — purely additive.
- The consuming syyclops-v3 PR bumps the submodule pointer to this branch and regenerates the ontology-sdk TypeScript from these files.
