### PR TITLE
Add memberOf/hasMember membership relationships between Asset and System

### DIFF
--- a/Ontology/Syyclops/Asset/Asset.json
+++ b/Ontology/Syyclops/Asset/Asset.json
@@ -46,6 +46,18 @@
     {
       "@type": "Relationship",
       "description": {
+        "en": "Indicates the System(s) this Asset is a member of (e.g., an air handler is a member of a supply-air system). Maps to IFC IfcRelAssignsToGroup. Inverse of: hasMember"
+      },
+      "displayName": {
+        "en": "member of"
+      },
+      "name": "memberOf",
+      "target": "dtmi:com:syyclops:System;1",
+      "@id": "dtmi:com:syyclops:Asset:memberOf;1"
+    },
+    {
+      "@type": "Relationship",
+      "description": {
         "en": "Indicates that an entity is included in some Collection, e.g., a Building is included in a RealEstate, or a Room is included in an Apartment. Inverse of: includes"
       },
       "displayName": {

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/System.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/System.json
@@ -76,6 +76,18 @@
       "name": "isPartOf",
       "target": "dtmi:com:syyclops:System;1",
       "@id": "dtmi:com:syyclops:System:isPartOf;1"
+    },
+    {
+      "@type": "Relationship",
+      "description": {
+        "en": "Indicates the member Assets (equipment and distribution assets such as ducts and pipes) that make up this system. Maps to IFC IfcRelAssignsToGroup. Inverse of: memberOf"
+      },
+      "displayName": {
+        "en": "has member"
+      },
+      "name": "hasMember",
+      "target": "dtmi:com:syyclops:Asset;1",
+      "@id": "dtmi:com:syyclops:System:hasMember;1"
     }
   ],
   "@context": [


### PR DESCRIPTION
## Overview

Adds a **System ↔ member-element** edge to the ontology so MEP systems (HVAC / electrical / plumbing) can be modeled as networks of their constituent assets, not just standalone collections. This is the ontology layer behind the BIM Systems feature (select a system → highlight its whole member network).

## Changes

- **`Asset.memberOf`** → `dtmi:com:syyclops:System;1` — the System(s) an Asset belongs to (e.g. an air handler is a member of a supply-air system).
- **`System.hasMember`** → `dtmi:com:syyclops:Asset;1` — inverse; the member Assets (equipment + distribution assets like ducts/pipes) that make up a system.

Both relationships map to IFC **`IfcRelAssignsToGroup`**.

## Notes

- Additive only — two new `Relationship` entries; no existing interfaces or relationships changed.
- Pairs with the existing `System.isPartOf` (System→System nesting) and `Asset.isPartOf`.
- Downstream `.ts` models are generated from these DTDL files via ontology-codegen.

Consuming PR: https://github.com/syyclops/syyclops/pull/2339
