### PR TITLE
feat: add hasMeter relationship to ElectricalDistributionEquipment

### DIFF
--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/ElectricalDistributionEquipment.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/ElectricalDistributionEquipment.json
@@ -64,6 +64,17 @@
       "description": {
         "en": "Classifies the load that the electrical distribution equipment is designed to support, aiding in performance assessment."
       }
+    },
+    {
+      "@type": "Relationship",
+      "name": "hasMeter",
+      "displayName": {
+        "en": "Has Meter"
+      },
+      "@id": "dtmi:com:syyclops:ElectricalDistributionEquipment:hasMeter;1",
+      "description": {
+        "en": "A relationship indicating that this electrical distribution equipment is metered by the linked device (e.g. a BACnet controller submeter)."
+      }
     }
   ],
   "@context": [


### PR DESCRIPTION
Allows an electrical distribution asset (e.g. a panelboard) to be linked to the metering device installed on it (a BACnetController submeter today, an ElectricalMeter in future). Target left open. Enables panelboard -> meter -> sensors traversal on the panel page.

Needed for https://app.clickup.com/t/90121834942/869dvjuae