### PR TITLE
New utility bill types.

### DIFF
--- a/Ontology/Syyclops/Account/UtilityAccount.json
+++ b/Ontology/Syyclops/Account/UtilityAccount.json
@@ -5,7 +5,7 @@
     "en": "Utility Account"
   },
   "description": {
-    "en": "A customer account in which the service provided is the delivery of a utility such as electricity, natural gas, or water."
+    "en": "A customer account in which the service provided is the delivery of a utility such as electricity, natural gas, water, internet, waste removal, or generator fuel."
   },
   "extends": [
     "dtmi:com:syyclops:Account;1"

--- a/Ontology/Syyclops/Event/Utility Bill/GarbageWasteBillEvent.json
+++ b/Ontology/Syyclops/Event/Utility Bill/GarbageWasteBillEvent.json
@@ -1,0 +1,76 @@
+{
+  "@id": "dtmi:com:syyclops:GarbageWasteBillEvent;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Garbage/Waste Removal Bill"
+  },
+  "description": {
+    "en": "A utility bill for garbage or waste removal service."
+  },
+  "extends": ["dtmi:com:syyclops:UtilityBillEvent;1"],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "meterData",
+      "displayName": {
+        "en": "Meter Data"
+      },
+      "description": {
+        "en": "Per-service readings on this bill. Each entry represents one waste service account or pickup location; readings in kilograms, tonnes, or US tons should be converted to pounds at ingestion."
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Array",
+        "elementSchema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "meterId",
+              "displayName": {
+                "en": "Meter Id"
+              },
+              "description": {
+                "en": "The service account or pickup location identifier as provided by the waste removal provider."
+              },
+              "schema": "string",
+              "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:meterId;1"
+            },
+            {
+              "name": "charge",
+              "displayName": {
+                "en": "Charge"
+              },
+              "description": {
+                "en": "The individual charge for this service's reading."
+              },
+              "schema": "dtmi:com:syyclops:UtilityBillEventCharges;1",
+              "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:charge;1"
+            },
+            {
+              "@type": ["Field", "Mass"],
+              "name": "consumption",
+              "displayName": {
+                "en": "Consumption"
+              },
+              "description": {
+                "en": "Total garbage or waste mass billed during the billing period for this service."
+              },
+              "schema": "double",
+              "unit": "massPound",
+              "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:consumption;1"
+            }
+          ],
+          "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:OS1;1"
+        },
+        "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:AS1;1"
+      },
+      "@id": "dtmi:com:syyclops:GarbageWasteBillEvent:meterData;1"
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
+  ]
+}

--- a/Ontology/Syyclops/Event/Utility Bill/GeneratorFuelBillEvent.json
+++ b/Ontology/Syyclops/Event/Utility Bill/GeneratorFuelBillEvent.json
@@ -1,0 +1,76 @@
+{
+  "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Generator Fuel Bill"
+  },
+  "description": {
+    "en": "A utility bill for generator fuel delivery or consumption."
+  },
+  "extends": ["dtmi:com:syyclops:UtilityBillEvent;1"],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "meterData",
+      "displayName": {
+        "en": "Meter Data"
+      },
+      "description": {
+        "en": "Per-delivery or per-tank readings on this bill. Each entry represents one fuel delivery or tank; readings in litres or cubic meters should be converted to gallons at ingestion (1 litre ≈ 0.264 gal, 1 m³ ≈ 264 gal)."
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Array",
+        "elementSchema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "meterId",
+              "displayName": {
+                "en": "Meter Id"
+              },
+              "description": {
+                "en": "The delivery or tank identifier as provided by the fuel supplier."
+              },
+              "schema": "string",
+              "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:meterId;1"
+            },
+            {
+              "name": "charge",
+              "displayName": {
+                "en": "Charge"
+              },
+              "description": {
+                "en": "The individual charge for this delivery or tank reading."
+              },
+              "schema": "dtmi:com:syyclops:UtilityBillEventCharges;1",
+              "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:charge;1"
+            },
+            {
+              "@type": ["Field", "Volume"],
+              "name": "consumption",
+              "displayName": {
+                "en": "Consumption"
+              },
+              "description": {
+                "en": "Total generator fuel volume billed during the billing period for this delivery or tank."
+              },
+              "schema": "double",
+              "unit": "gallon",
+              "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:consumption;1"
+            }
+          ],
+          "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:OS1;1"
+        },
+        "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:AS1;1"
+      },
+      "@id": "dtmi:com:syyclops:GeneratorFuelBillEvent:meterData;1"
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
+  ]
+}

--- a/Ontology/Syyclops/Event/Utility Bill/InternetBillEvent.json
+++ b/Ontology/Syyclops/Event/Utility Bill/InternetBillEvent.json
@@ -1,0 +1,63 @@
+{
+  "@id": "dtmi:com:syyclops:InternetBillEvent;1",
+  "@type": "Interface",
+  "displayName": {
+    "en": "Internet Bill"
+  },
+  "description": {
+    "en": "A utility bill for internet or telecom service."
+  },
+  "extends": ["dtmi:com:syyclops:UtilityBillEvent;1"],
+  "contents": [
+    {
+      "@type": "Property",
+      "name": "meterData",
+      "displayName": {
+        "en": "Meter Data"
+      },
+      "description": {
+        "en": "Per-service-line charges on this bill. Each entry represents one service account or circuit; fill only the fields the provider reports."
+      },
+      "writable": true,
+      "schema": {
+        "@type": "Array",
+        "elementSchema": {
+          "@type": "Object",
+          "fields": [
+            {
+              "name": "meterId",
+              "displayName": {
+                "en": "Meter Id"
+              },
+              "description": {
+                "en": "The service account or line identifier as provided by the internet or telecom provider."
+              },
+              "schema": "string",
+              "@id": "dtmi:com:syyclops:InternetBillEvent:meterId;1"
+            },
+            {
+              "name": "charge",
+              "displayName": {
+                "en": "Charge"
+              },
+              "description": {
+                "en": "The individual charge for this service line."
+              },
+              "schema": "dtmi:com:syyclops:UtilityBillEventCharges;1",
+              "@id": "dtmi:com:syyclops:InternetBillEvent:charge;1"
+            }
+          ],
+          "@id": "dtmi:com:syyclops:InternetBillEvent:OS1;1"
+        },
+        "@id": "dtmi:com:syyclops:InternetBillEvent:AS1;1"
+      },
+      "@id": "dtmi:com:syyclops:InternetBillEvent:meterData;1"
+    }
+  ],
+  "@context": [
+    "dtmi:dtdl:context;3",
+    "dtmi:dtdl:extension:quantitativeTypes;1",
+    "dtmi:dtdl:extension:annotation;1",
+    "dtmi:dtdl:extension:overriding;1"
+  ]
+}

--- a/Ontology/Syyclops/Event/Utility Bill/UtilityBillEvent.json
+++ b/Ontology/Syyclops/Event/Utility Bill/UtilityBillEvent.json
@@ -5,7 +5,7 @@
     "en": "Utility Bill"
   },
   "description": {
-    "en": "An event that occurs, typically monthly, when a utility company produces a bill for a utility account. Defines fields common to all service types; concrete bill types (electricity, natural gas, potable water, reclaimed water) extend this and add their service-specific meter data and charge structure."
+    "en": "An event that occurs, typically monthly, when a utility company produces a bill for a utility account. Defines fields common to all service types; concrete bill types (electricity, natural gas, potable water, reclaimed water, internet, garbage/waste removal, generator fuel) extend this and add their service-specific meter data and charge structure."
   },
   "extends": ["dtmi:com:syyclops:Event;1"],
   "contents": [


### PR DESCRIPTION
Added GarbageWasteBillEvent, GeneratorFuelBillEvent, and InternetBillEvent types extending UtilityBillEvent.
Each has its own meterData schema: waste mass (pounds), fuel volume (gallons), internet per-line charges (no consumption)

Needed for https://app.clickup.com/t/90121834942/869e2wkqk