### PR TITLE
feat: add displayName.en to all enum values

### DIFF
--- a/Ontology/Syyclops/Asset/Architectural Asset/Barrier Asset/BarrierAsset.json
+++ b/Ontology/Syyclops/Asset/Architectural Asset/Barrier Asset/BarrierAsset.json
@@ -115,11 +115,17 @@
         "enumValues": [
           {
             "enumValue": "Interior",
+            "displayName": {
+              "en": "Interior"
+            },
             "name": "Interior",
             "@id": "dtmi:com:syyclops:BarrierAsset:Interior;1"
           },
           {
             "enumValue": "Exterior",
+            "displayName": {
+              "en": "Exterior"
+            },
             "name": "Exterior",
             "@id": "dtmi:com:syyclops:BarrierAsset:Exterior;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Airport/Airfield Lighting/AirfieldLightingEquipment.json
+++ b/Ontology/Syyclops/Asset/Equipment/Airport/Airfield Lighting/AirfieldLightingEquipment.json
@@ -22,19 +22,25 @@
         "enumValues": [
           {
             "name": "low",
-            "displayName": "Low",
+            "displayName": {
+              "en": "Low"
+            },
             "enumValue": "Low",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:low;1"
           },
           {
             "name": "medium",
-            "displayName": "Medium",
+            "displayName": {
+              "en": "Medium"
+            },
             "enumValue": "Medium",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:medium;1"
           },
           {
             "name": "high",
-            "displayName": "High",
+            "displayName": {
+              "en": "High"
+            },
             "enumValue": "High",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:high;1"
           }
@@ -67,13 +73,17 @@
               "enumValues": [
                 {
                   "name": "elevated",
-                  "displayName": "Elevated",
+                  "displayName": {
+                    "en": "Elevated"
+                  },
                   "enumValue": "Elevated",
                   "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:elevated;1"
                 },
                 {
                   "name": "inset",
-                  "displayName": "Inset",
+                  "displayName": {
+                    "en": "Inset"
+                  },
                   "enumValue": "Inset",
                   "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:inset;1"
                 }
@@ -93,19 +103,25 @@
               "enumValues": [
                 {
                   "name": "base",
-                  "displayName": "Base",
+                  "displayName": {
+                    "en": "Base"
+                  },
                   "enumValue": "Base",
                   "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:base;1"
                 },
                 {
                   "name": "stake",
-                  "displayName": "Stake",
+                  "displayName": {
+                    "en": "Stake"
+                  },
                   "enumValue": "Stake",
                   "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:stake;1"
                 },
                 {
                   "name": "direct",
-                  "displayName": "Direct",
+                  "displayName": {
+                    "en": "Direct"
+                  },
                   "enumValue": "Direct",
                   "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:direct;1"
                 }
@@ -135,19 +151,25 @@
         "enumValues": [
           {
             "name": "unidirectional",
-            "displayName": "Unidirectional",
+            "displayName": {
+              "en": "Unidirectional"
+            },
             "enumValue": "Unidirectional",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:unidirectional;1"
           },
           {
             "name": "bidirectional",
-            "displayName": "Bidirectional",
+            "displayName": {
+              "en": "Bidirectional"
+            },
             "enumValue": "Bidirectional",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:bidirectional;1"
           },
           {
             "name": "omnidirectional",
-            "displayName": "Omnidirectional",
+            "displayName": {
+              "en": "Omnidirectional"
+            },
             "enumValue": "Omnidirectional",
             "@id": "dtmi:com:syyclops:airport:AirfieldLightingEquipment:omnidirectional;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Busway/Busway.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Busway/Busway.json
@@ -49,11 +49,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:Busway:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:Busway:One;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Panelboard/ElectricalPanelboard.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Panelboard/ElectricalPanelboard.json
@@ -32,11 +32,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:ElectricalPanelboard:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:ElectricalPanelboard:One;1"
           }
@@ -105,13 +111,17 @@
         "enumValues": [
           {
             "name": "One",
-            "displayName": "1",
+            "displayName": {
+              "en": "1"
+            },
             "enumValue": "1",
             "@id": "dtmi:com:syyclops:ElectricalPanelboard:EE3;1"
           },
           {
             "name": "Three",
-            "displayName": "3",
+            "displayName": {
+              "en": "3"
+            },
             "enumValue": "3",
             "@id": "dtmi:com:syyclops:ElectricalPanelboard:EE4;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Wiring Device/Electrical Receptacle/ElectricalReceptacle.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Wiring Device/Electrical Receptacle/ElectricalReceptacle.json
@@ -55,19 +55,25 @@
         "enumValues": [
           {
             "name": "One",
-            "displayName": "1",
+            "displayName": {
+              "en": "1"
+            },
             "enumValue": "1",
             "@id": "dtmi:com:syyclops:ElectricalReceptacle:One;1"
           },
           {
             "name": "Two",
-            "displayName": "2",
+            "displayName": {
+              "en": "2"
+            },
             "enumValue": "2",
             "@id": "dtmi:com:syyclops:ElectricalReceptacle:Two;1"
           },
           {
             "name": "Three",
-            "displayName": "3",
+            "displayName": {
+              "en": "3"
+            },
             "enumValue": "3",
             "@id": "dtmi:com:syyclops:ElectricalReceptacle:Three;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Wiring Device/Electrical Switch/ElectricalSwitch.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Electrical Wiring Device/Electrical Switch/ElectricalSwitch.json
@@ -55,19 +55,25 @@
         "enumValues": [
           {
             "name": "One",
-            "displayName": "1",
+            "displayName": {
+              "en": "1"
+            },
             "enumValue": "1",
             "@id": "dtmi:com:syyclops:ElectricalSwitch:One;1"
           },
           {
             "name": "Two",
-            "displayName": "2",
+            "displayName": {
+              "en": "2"
+            },
             "enumValue": "2",
             "@id": "dtmi:com:syyclops:ElectricalSwitch:Two;1"
           },
           {
             "name": "Three",
-            "displayName": "3",
+            "displayName": {
+              "en": "3"
+            },
             "enumValue": "3",
             "@id": "dtmi:com:syyclops:ElectricalSwitch:Three;1"
           }
@@ -92,13 +98,17 @@
         "enumValues": [
           {
             "name": "One",
-            "displayName": "1",
+            "displayName": {
+              "en": "1"
+            },
             "enumValue": "1",
             "@id": "dtmi:com:syyclops:ElectricalSwitch:EE3;1"
           },
           {
             "name": "Two",
-            "displayName": "2",
+            "displayName": {
+              "en": "2"
+            },
             "enumValue": "2",
             "@id": "dtmi:com:syyclops:ElectricalSwitch:EE4;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Motor Controller/Variable Frequency Drive/VariableFrequencyDrive.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Motor Controller/Variable Frequency Drive/VariableFrequencyDrive.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "VoltageSourceInverter",
+            "displayName": {
+              "en": "Voltage Source Inverter"
+            },
             "name": "VoltageSourceInverter",
             "@id": "dtmi:com:syyclops:VariableFrequencyDrive:VoltageSourceInverter;1"
           },
           {
             "enumValue": "PulseWidthModulation",
+            "displayName": {
+              "en": "Pulse Width Modulation"
+            },
             "name": "PulseWidthModulation",
             "@id": "dtmi:com:syyclops:VariableFrequencyDrive:PulseWidthModulation;1"
           },
           {
             "enumValue": "CurrentSourceInverter",
+            "displayName": {
+              "en": "Current Source Inverter"
+            },
             "name": "CurrentSourceInverter",
             "@id": "dtmi:com:syyclops:VariableFrequencyDrive:CurrentSourceInverter;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Switchboard/Switchboard.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Switchboard/Switchboard.json
@@ -49,11 +49,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:Switchboard:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:Switchboard:One;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Switchgear/Switchgear.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Switchgear/Switchgear.json
@@ -49,11 +49,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:Switchgear:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:Switchgear:One;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transfer Switch/AutomaticTransferSwitch.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transfer Switch/AutomaticTransferSwitch.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "Open",
+            "displayName": {
+              "en": "Open"
+            },
             "name": "Open",
             "@id": "dtmi:com:syyclops:AutomaticTransferSwitch:Open;1"
           },
           {
             "enumValue": "Closed",
+            "displayName": {
+              "en": "Closed"
+            },
             "name": "Closed",
             "@id": "dtmi:com:syyclops:AutomaticTransferSwitch:Closed;1"
           }
@@ -48,16 +54,25 @@
         "enumValues": [
           {
             "enumValue": "Contactor",
+            "displayName": {
+              "en": "Contactor"
+            },
             "name": "Contactor",
             "@id": "dtmi:com:syyclops:AutomaticTransferSwitch:Contactor;1"
           },
           {
             "enumValue": "CircuitBreakerPowerCase",
+            "displayName": {
+              "en": "Power-Case Circuit Breaker"
+            },
             "name": "CircuitBreakerPowerCase",
             "@id": "dtmi:com:syyclops:AutomaticTransferSwitch:CircuitBreakerPowerCase;1"
           },
           {
             "enumValue": "CircuitBreakerMoldedCase",
+            "displayName": {
+              "en": "Molded-Case Circuit Breaker"
+            },
             "name": "CircuitBreakerMoldedCase",
             "@id": "dtmi:com:syyclops:AutomaticTransferSwitch:CircuitBreakerMoldedCase;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transfer Switch/TransferSwitch.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transfer Switch/TransferSwitch.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:TransferSwitch:Three;1"
           },
           {
             "enumValue": "Four",
+            "displayName": {
+              "en": "Four"
+            },
             "name": "Four",
             "@id": "dtmi:com:syyclops:TransferSwitch:Four;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transformer/Transformer.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Distribution/Transformer/Transformer.json
@@ -83,11 +83,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:Transformer:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:Transformer:One;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Generation Storage/Generator/Generator.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Generation Storage/Generator/Generator.json
@@ -36,11 +36,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:Generator:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:Generator:One;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Generation Storage/UPS.json
+++ b/Ontology/Syyclops/Asset/Equipment/Electrical/Electrical Generation Storage/UPS.json
@@ -87,11 +87,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:UPS:Three;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:UPS:One;1"
           }
@@ -133,11 +139,17 @@
         "enumValues": [
           {
             "enumValue": "Three",
+            "displayName": {
+              "en": "Three"
+            },
             "name": "Three",
             "@id": "dtmi:com:syyclops:UPS:EE3;1"
           },
           {
             "enumValue": "One",
+            "displayName": {
+              "en": "One"
+            },
             "name": "One",
             "@id": "dtmi:com:syyclops:UPS:EE4;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Equipment.json
+++ b/Ontology/Syyclops/Asset/Equipment/Equipment.json
@@ -74,6 +74,9 @@
       "enumValues": [
         {
           "enumValue": "Water",
+          "displayName": {
+            "en": "Water"
+          },
           "name": "Water",
           "@id": "dtmi:com:syyclops:Equipment:Water;1",
           "description": {
@@ -82,6 +85,9 @@
         },
         {
           "enumValue": "WasteVentDrainage",
+          "displayName": {
+            "en": "Waste Vent Drainage"
+          },
           "name": "WasteVentDrainage",
           "@id": "dtmi:com:syyclops:Equipment:WasteVentDrainage;1",
           "description": {
@@ -90,6 +96,9 @@
         },
         {
           "enumValue": "TransferAir",
+          "displayName": {
+            "en": "Transfer Air"
+          },
           "name": "TransferAir",
           "@id": "dtmi:com:syyclops:Equipment:TransferAir;1",
           "description": {
@@ -98,6 +107,9 @@
         },
         {
           "enumValue": "SupplyAir",
+          "displayName": {
+            "en": "Supply Air"
+          },
           "name": "SupplyAir",
           "@id": "dtmi:com:syyclops:Equipment:SupplyAir;1",
           "description": {
@@ -106,6 +118,9 @@
         },
         {
           "enumValue": "StormDrainage",
+          "displayName": {
+            "en": "Storm Drainage"
+          },
           "name": "StormDrainage",
           "@id": "dtmi:com:syyclops:Equipment:StormDrainage;1",
           "description": {
@@ -114,6 +129,9 @@
         },
         {
           "enumValue": "Steam",
+          "displayName": {
+            "en": "Steam"
+          },
           "name": "Steam",
           "@id": "dtmi:com:syyclops:Equipment:Steam;1",
           "description": {
@@ -122,6 +140,9 @@
         },
         {
           "enumValue": "SprinklerWater",
+          "displayName": {
+            "en": "Sprinkler Water"
+          },
           "name": "SprinklerWater",
           "@id": "dtmi:com:syyclops:Equipment:SprinklerWater;1",
           "description": {
@@ -130,6 +151,9 @@
         },
         {
           "enumValue": "ReturnAir",
+          "displayName": {
+            "en": "Return Air"
+          },
           "name": "ReturnAir",
           "@id": "dtmi:com:syyclops:Equipment:ReturnAir;1",
           "description": {
@@ -138,6 +162,9 @@
         },
         {
           "enumValue": "Refrig",
+          "displayName": {
+            "en": "Refrigerant"
+          },
           "name": "Refrig",
           "@id": "dtmi:com:syyclops:Equipment:Refrig;1",
           "description": {
@@ -146,6 +173,9 @@
         },
         {
           "enumValue": "RecircHotDomesticWater",
+          "displayName": {
+            "en": "Recirculating Hot Domestic Water"
+          },
           "name": "RecircHotDomesticWater",
           "@id": "dtmi:com:syyclops:Equipment:RecircHotDomesticWater;1",
           "description": {
@@ -154,6 +184,9 @@
         },
         {
           "enumValue": "Propane",
+          "displayName": {
+            "en": "Propane"
+          },
           "name": "Propane",
           "@id": "dtmi:com:syyclops:Equipment:Propane;1",
           "description": {
@@ -162,6 +195,9 @@
         },
         {
           "enumValue": "OutsideAir",
+          "displayName": {
+            "en": "Outside Air"
+          },
           "name": "OutsideAir",
           "@id": "dtmi:com:syyclops:Equipment:OutsideAir;1",
           "description": {
@@ -170,6 +206,9 @@
         },
         {
           "enumValue": "NonPotableDomesticWater",
+          "displayName": {
+            "en": "Non-Potable Domestic Water"
+          },
           "name": "NonPotableDomesticWater",
           "@id": "dtmi:com:syyclops:Equipment:NonPotableDomesticWater;1",
           "description": {
@@ -178,6 +217,9 @@
         },
         {
           "enumValue": "NaturalGas",
+          "displayName": {
+            "en": "Natural Gas"
+          },
           "name": "NaturalGas",
           "@id": "dtmi:com:syyclops:Equipment:NaturalGas;1",
           "description": {
@@ -186,6 +228,9 @@
         },
         {
           "enumValue": "MakeupWater",
+          "displayName": {
+            "en": "Makeup Water"
+          },
           "name": "MakeupWater",
           "@id": "dtmi:com:syyclops:Equipment:MakeupWater;1",
           "description": {
@@ -194,6 +239,9 @@
         },
         {
           "enumValue": "Light",
+          "displayName": {
+            "en": "Light"
+          },
           "name": "Light",
           "@id": "dtmi:com:syyclops:Equipment:Light;1",
           "description": {
@@ -202,6 +250,9 @@
         },
         {
           "enumValue": "IrrigationWater",
+          "displayName": {
+            "en": "Irrigation Water"
+          },
           "name": "IrrigationWater",
           "@id": "dtmi:com:syyclops:Equipment:IrrigationWater;1",
           "description": {
@@ -210,6 +261,9 @@
         },
         {
           "enumValue": "HotWater",
+          "displayName": {
+            "en": "Hot Water"
+          },
           "name": "HotWater",
           "@id": "dtmi:com:syyclops:Equipment:HotWater;1",
           "description": {
@@ -218,6 +272,9 @@
         },
         {
           "enumValue": "HotWaterGlycolMix",
+          "displayName": {
+            "en": "Hot Water Glycol Mix"
+          },
           "name": "HotWaterGlycolMix",
           "@id": "dtmi:com:syyclops:Equipment:HotWaterGlycolMix;1",
           "description": {
@@ -226,6 +283,9 @@
         },
         {
           "enumValue": "HotDomesticWater",
+          "displayName": {
+            "en": "Hot Domestic Water"
+          },
           "name": "HotDomesticWater",
           "@id": "dtmi:com:syyclops:Equipment:HotDomesticWater;1",
           "description": {
@@ -234,6 +294,9 @@
         },
         {
           "enumValue": "GreaseExhaustAir",
+          "displayName": {
+            "en": "Grease Exhaust Air"
+          },
           "name": "GreaseExhaustAir",
           "@id": "dtmi:com:syyclops:Equipment:GreaseExhaustAir;1",
           "description": {
@@ -242,6 +305,9 @@
         },
         {
           "enumValue": "Gasoline",
+          "displayName": {
+            "en": "Gasoline"
+          },
           "name": "Gasoline",
           "@id": "dtmi:com:syyclops:Equipment:Gasoline;1",
           "description": {
@@ -250,6 +316,9 @@
         },
         {
           "enumValue": "FuelOil",
+          "displayName": {
+            "en": "Fuel Oil"
+          },
           "name": "FuelOil",
           "@id": "dtmi:com:syyclops:Equipment:FuelOil;1",
           "description": {
@@ -258,6 +327,9 @@
         },
         {
           "enumValue": "Freight",
+          "displayName": {
+            "en": "Freight"
+          },
           "name": "Freight",
           "@id": "dtmi:com:syyclops:Equipment:Freight;1",
           "description": {
@@ -266,6 +338,9 @@
         },
         {
           "enumValue": "ExhaustAir",
+          "displayName": {
+            "en": "Exhaust Air"
+          },
           "name": "ExhaustAir",
           "@id": "dtmi:com:syyclops:Equipment:ExhaustAir;1",
           "description": {
@@ -274,6 +349,9 @@
         },
         {
           "enumValue": "Ethernet",
+          "displayName": {
+            "en": "Ethernet"
+          },
           "name": "Ethernet",
           "@id": "dtmi:com:syyclops:Equipment:Ethernet;1",
           "description": {
@@ -282,6 +360,9 @@
         },
         {
           "enumValue": "DriveElec",
+          "displayName": {
+            "en": "Drive Electricity"
+          },
           "name": "DriveElec",
           "@id": "dtmi:com:syyclops:Equipment:DriveElec;1",
           "description": {
@@ -290,6 +371,9 @@
         },
         {
           "enumValue": "Diesel",
+          "displayName": {
+            "en": "Diesel"
+          },
           "name": "Diesel",
           "@id": "dtmi:com:syyclops:Equipment:Diesel;1",
           "description": {
@@ -298,6 +382,9 @@
         },
         {
           "enumValue": "DCElec",
+          "displayName": {
+            "en": "DC Electricity"
+          },
           "name": "DCElec",
           "@id": "dtmi:com:syyclops:Equipment:DCElec;1",
           "description": {
@@ -306,6 +393,9 @@
         },
         {
           "enumValue": "CondenserWater",
+          "displayName": {
+            "en": "Condenser Water"
+          },
           "name": "CondenserWater",
           "@id": "dtmi:com:syyclops:Equipment:CondenserWater;1",
           "description": {
@@ -314,6 +404,9 @@
         },
         {
           "enumValue": "CondenserWaterGlycolMix",
+          "displayName": {
+            "en": "Condenser Water Glycol Mix"
+          },
           "name": "CondenserWaterGlycolMix",
           "@id": "dtmi:com:syyclops:Equipment:CondenserWaterGlycolMix;1",
           "description": {
@@ -322,6 +415,9 @@
         },
         {
           "enumValue": "Condensate",
+          "displayName": {
+            "en": "Condensate"
+          },
           "name": "Condensate",
           "@id": "dtmi:com:syyclops:Equipment:Condensate;1",
           "description": {
@@ -330,6 +426,9 @@
         },
         {
           "enumValue": "ColdDomesticWater",
+          "displayName": {
+            "en": "Cold Domestic Water"
+          },
           "name": "ColdDomesticWater",
           "@id": "dtmi:com:syyclops:Equipment:ColdDomesticWater;1",
           "description": {
@@ -338,6 +437,9 @@
         },
         {
           "enumValue": "ChilledWater",
+          "displayName": {
+            "en": "Chilled Water"
+          },
           "name": "ChilledWater",
           "@id": "dtmi:com:syyclops:Equipment:ChilledWater;1",
           "description": {
@@ -346,6 +448,9 @@
         },
         {
           "enumValue": "BlowdownWater",
+          "displayName": {
+            "en": "Blowdown Water"
+          },
           "name": "BlowdownWater",
           "@id": "dtmi:com:syyclops:Equipment:BlowdownWater;1",
           "description": {
@@ -354,6 +459,9 @@
         },
         {
           "enumValue": "Air",
+          "displayName": {
+            "en": "Air"
+          },
           "name": "Air",
           "@id": "dtmi:com:syyclops:Equipment:Air;1",
           "description": {
@@ -362,6 +470,9 @@
         },
         {
           "enumValue": "ACElec",
+          "displayName": {
+            "en": "AC Electricity"
+          },
           "name": "ACElec",
           "@id": "dtmi:com:syyclops:Equipment:ACElec;1",
           "description": {

--- a/Ontology/Syyclops/Asset/Equipment/Fire Protection/Fire Suppression/Sprinkler/FireSprinklerHead.json
+++ b/Ontology/Syyclops/Asset/Equipment/Fire Protection/Fire Suppression/Sprinkler/FireSprinklerHead.json
@@ -19,21 +19,33 @@
         "enumValues": [
           {
             "enumValue": "Upright",
+            "displayName": {
+              "en": "Upright"
+            },
             "name": "Upright",
             "@id": "dtmi:com:syyclops:FireSprinklerHead:Upright;1"
           },
           {
             "enumValue": "SideWall",
+            "displayName": {
+              "en": "Sidewall"
+            },
             "name": "SideWall",
             "@id": "dtmi:com:syyclops:FireSprinklerHead:SideWall;1"
           },
           {
             "enumValue": "Pendant",
+            "displayName": {
+              "en": "Pendant"
+            },
             "name": "Pendant",
             "@id": "dtmi:com:syyclops:FireSprinklerHead:Pendant;1"
           },
           {
             "enumValue": "ConcealedPendant",
+            "displayName": {
+              "en": "Concealed Pendant"
+            },
             "name": "ConcealedPendant",
             "@id": "dtmi:com:syyclops:FireSprinklerHead:ConcealedPendant;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Fire Protection/Fire Suppression/Sprinkler/Valve/SprinklerShutOffValve.json
+++ b/Ontology/Syyclops/Asset/Equipment/Fire Protection/Fire Suppression/Sprinkler/Valve/SprinklerShutOffValve.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "Gate",
+            "displayName": {
+              "en": "Gate"
+            },
             "name": "Gate",
             "@id": "dtmi:com:syyclops:SprinklerShutOffValve:Gate;1"
           },
           {
             "enumValue": "Butterfly",
+            "displayName": {
+              "en": "Butterfly"
+            },
             "name": "Butterfly",
             "@id": "dtmi:com:syyclops:SprinklerShutOffValve:Butterfly;1"
           },
           {
             "enumValue": "Ball",
+            "displayName": {
+              "en": "Ball"
+            },
             "name": "Ball",
             "@id": "dtmi:com:syyclops:SprinklerShutOffValve:Ball;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/General-purpose/Compressor.json
+++ b/Ontology/Syyclops/Asset/Equipment/General-purpose/Compressor.json
@@ -36,26 +36,41 @@
         "enumValues": [
           {
             "enumValue": "Scroll",
+            "displayName": {
+              "en": "Scroll"
+            },
             "name": "Scroll",
             "@id": "dtmi:com:syyclops:Compressor:Scroll;1"
           },
           {
             "enumValue": "Screw",
+            "displayName": {
+              "en": "Screw"
+            },
             "name": "Screw",
             "@id": "dtmi:com:syyclops:Compressor:Screw;1"
           },
           {
             "enumValue": "Reciprocol",
+            "displayName": {
+              "en": "Reciprocating"
+            },
             "name": "Reciprocol",
             "@id": "dtmi:com:syyclops:Compressor:Reciprocol;1"
           },
           {
             "enumValue": "Centrifugal",
+            "displayName": {
+              "en": "Centrifugal"
+            },
             "name": "Centrifugal",
             "@id": "dtmi:com:syyclops:Compressor:Centrifugal;1"
           },
           {
             "enumValue": "Absorption",
+            "displayName": {
+              "en": "Absorption"
+            },
             "name": "Absorption",
             "@id": "dtmi:com:syyclops:Compressor:Absorption;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/General-purpose/EnergyRecoveryDevice.json
+++ b/Ontology/Syyclops/Asset/Equipment/General-purpose/EnergyRecoveryDevice.json
@@ -36,31 +36,49 @@
         "enumValues": [
           {
             "enumValue": "Sensible Energy Wheel",
+            "displayName": {
+              "en": "Sensible Energy Wheel"
+            },
             "name": "SensibleEnergyWheel",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:SensibleEnergyWheel;1"
           },
           {
             "enumValue": "Enthalpy Wheel",
+            "displayName": {
+              "en": "Enthalpy Wheel"
+            },
             "name": "EnthalpyWheel",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:EnthalpyWheel;1"
           },
           {
             "enumValue": "DualWheel",
+            "displayName": {
+              "en": "Dual Wheel"
+            },
             "name": "DualWheel",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:DualWheel;1"
           },
           {
             "enumValue": "Sensible Energy Core",
+            "displayName": {
+              "en": "Sensible Energy Core"
+            },
             "name": "SensibleEnergyCore",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:SensibleEnergyCore;1"
           },
           {
             "enumValue": "Enthalpy Core",
+            "displayName": {
+              "en": "Enthalpy Core"
+            },
             "name": "EnthalpyCore",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:EnthalpyCore;1"
           },
           {
             "enumValue": "DualCoils",
+            "displayName": {
+              "en": "Dual Coils"
+            },
             "name": "DualCoils",
             "@id": "dtmi:com:syyclops:EnergyRecoveryDevice:DualCoils;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/General-purpose/Fan.json
+++ b/Ontology/Syyclops/Asset/Equipment/General-purpose/Fan.json
@@ -450,11 +450,17 @@
         "enumValues": [
           {
             "enumValue": "Direct",
+            "displayName": {
+              "en": "Direct"
+            },
             "name": "Direct",
             "@id": "dtmi:com:syyclops:Fan:Direct;1"
           },
           {
             "enumValue": "Belt",
+            "displayName": {
+              "en": "Belt"
+            },
             "name": "Belt",
             "@id": "dtmi:com:syyclops:Fan:Belt;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/General-purpose/HeatTracing.json
+++ b/Ontology/Syyclops/Asset/Equipment/General-purpose/HeatTracing.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "SelfRegulating",
+            "displayName": {
+              "en": "Self-Regulating"
+            },
             "name": "SelfRegulating",
             "@id": "dtmi:com:syyclops:HeatTracing:SelfRegulating;1"
           },
           {
             "enumValue": "ConstantWattage",
+            "displayName": {
+              "en": "Constant Wattage"
+            },
             "name": "ConstantWattage",
             "@id": "dtmi:com:syyclops:HeatTracing:ConstantWattage;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/General-purpose/Pump.json
+++ b/Ontology/Syyclops/Asset/Equipment/General-purpose/Pump.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "vertical",
+            "displayName": {
+              "en": "Vertical"
+            },
             "name": "vertical",
             "@id": "dtmi:com:syyclops:Pump:vertical;1"
           },
           {
             "enumValue": "inline",
+            "displayName": {
+              "en": "Inline"
+            },
             "name": "inline",
             "@id": "dtmi:com:syyclops:Pump:inline;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Air Filter/AirFilter.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Air Filter/AirFilter.json
@@ -31,16 +31,25 @@
         "enumValues": [
           {
             "enumValue": "MERV",
+            "displayName": {
+              "en": "MERV"
+            },
             "name": "MERV",
             "@id": "dtmi:com:syyclops:AirFilter:MERV;1"
           },
           {
             "enumValue": "HEPA",
+            "displayName": {
+              "en": "HEPA"
+            },
             "name": "HEPA",
             "@id": "dtmi:com:syyclops:AirFilter:HEPA;1"
           },
           {
             "enumValue": "ULPA",
+            "displayName": {
+              "en": "ULPA"
+            },
             "name": "ULPA",
             "@id": "dtmi:com:syyclops:AirFilter:ULPA;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Air Handling Unit/AirHandlingUnit.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Air Handling Unit/AirHandlingUnit.json
@@ -22,21 +22,33 @@
         "enumValues": [
           {
             "enumValue": "VAVZone",
+            "displayName": {
+              "en": "VAV Zone"
+            },
             "name": "VAVZone",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:VAVZone;1"
           },
           {
             "enumValue": "MultiZone",
+            "displayName": {
+              "en": "Multi-Zone"
+            },
             "name": "MultiZone",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:MultiZone;1"
           },
           {
             "enumValue": "DirectZone",
+            "displayName": {
+              "en": "Direct Zone"
+            },
             "name": "DirectZone",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:DirectZone;1"
           },
           {
             "enumValue": "ChilledBeamZone",
+            "displayName": {
+              "en": "Chilled Beam Zone"
+            },
             "name": "ChilledBeamZone",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:ChilledBeamZone;1"
           }
@@ -61,21 +73,33 @@
         "enumValues": [
           {
             "enumValue": "None",
+            "displayName": {
+              "en": "None"
+            },
             "name": "None",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:None;1"
           },
           {
             "enumValue": "Economizing",
+            "displayName": {
+              "en": "Economizing"
+            },
             "name": "Economizing",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Economizing;1"
           },
           {
             "enumValue": "DemandEconomizing",
+            "displayName": {
+              "en": "Demand Economizing"
+            },
             "name": "DemandEconomizing",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:DemandEconomizing;1"
           },
           {
             "enumValue": "Demand",
+            "displayName": {
+              "en": "Demand"
+            },
             "name": "Demand",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Demand;1"
           }
@@ -100,16 +124,25 @@
         "enumValues": [
           {
             "enumValue": "OA",
+            "displayName": {
+              "en": "Outside Air"
+            },
             "name": "OA",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:OA;1"
           },
           {
             "enumValue": "None",
+            "displayName": {
+              "en": "None"
+            },
             "name": "None",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE4;1"
           },
           {
             "enumValue": "MixedAir",
+            "displayName": {
+              "en": "Mixed Air"
+            },
             "name": "MixedAir",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:MixedAir;1"
           }
@@ -374,21 +407,33 @@
         "enumValues": [
           {
             "enumValue": "Ultrasonic",
+            "displayName": {
+              "en": "Ultrasonic"
+            },
             "name": "Ultrasonic",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Ultrasonic;1"
           },
           {
             "enumValue": "Steam",
+            "displayName": {
+              "en": "Steam"
+            },
             "name": "Steam",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Steam;1"
           },
           {
             "enumValue": "None",
+            "displayName": {
+              "en": "None"
+            },
             "name": "None",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE6;1"
           },
           {
             "enumValue": "Adiabatic",
+            "displayName": {
+              "en": "Adiabatic"
+            },
             "name": "Adiabatic",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Adiabatic;1"
           }
@@ -426,16 +471,25 @@
         "enumValues": [
           {
             "enumValue": "TripleDuct",
+            "displayName": {
+              "en": "Triple Duct"
+            },
             "name": "TripleDuct",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:TripleDuct;1"
           },
           {
             "enumValue": "SingleDuct",
+            "displayName": {
+              "en": "Single Duct"
+            },
             "name": "SingleDuct",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:SingleDuct;1"
           },
           {
             "enumValue": "DualDuct",
+            "displayName": {
+              "en": "Dual Duct"
+            },
             "name": "DualDuct",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:DualDuct;1"
           }
@@ -460,36 +514,57 @@
         "enumValues": [
           {
             "enumValue": "WrapAroundCoil",
+            "displayName": {
+              "en": "Wrap-Around Coil"
+            },
             "name": "WrapAroundCoil",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:WrapAroundCoil;1"
           },
           {
             "enumValue": "TieredCooling",
+            "displayName": {
+              "en": "Tiered Cooling"
+            },
             "name": "TieredCooling",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:TieredCooling;1"
           },
           {
             "enumValue": "None",
+            "displayName": {
+              "en": "None"
+            },
             "name": "None",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE9;1"
           },
           {
             "enumValue": "EnthalpyWheel",
+            "displayName": {
+              "en": "Enthalpy Wheel"
+            },
             "name": "EnthalpyWheel",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EnthalpyWheel;1"
           },
           {
             "enumValue": "DualWheel",
+            "displayName": {
+              "en": "Dual Wheel"
+            },
             "name": "DualWheel",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:DualWheel;1"
           },
           {
             "enumValue": "Desiccant",
+            "displayName": {
+              "en": "Desiccant"
+            },
             "name": "Desiccant",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:Desiccant;1"
           },
           {
             "enumValue": "CoolReheat",
+            "displayName": {
+              "en": "Cool Reheat"
+            },
             "name": "CoolReheat",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:CoolReheat;1"
           }
@@ -514,26 +589,41 @@
         "enumValues": [
           {
             "enumValue": "None",
+            "displayName": {
+              "en": "None"
+            },
             "name": "None",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE11;1"
           },
           {
             "enumValue": "SensibleEnergyWheel",
+            "displayName": {
+              "en": "Sensible Energy Wheel"
+            },
             "name": "SensibleEnergyWheel",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:SensibleEnergyWheel;1"
           },
           {
             "enumValue": "EnthalpyWheel",
+            "displayName": {
+              "en": "Enthalpy Wheel"
+            },
             "name": "EnthalpyWheel",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE12;1"
           },
           {
             "enumValue": "DualWheel",
+            "displayName": {
+              "en": "Dual Wheel"
+            },
             "name": "DualWheel",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:EE13;1"
           },
           {
             "enumValue": "DualCoils",
+            "displayName": {
+              "en": "Dual Coils"
+            },
             "name": "DualCoils",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:DualCoils;1"
           }
@@ -558,11 +648,17 @@
         "enumValues": [
           {
             "enumValue": "VariableVolume",
+            "displayName": {
+              "en": "Variable Volume"
+            },
             "name": "VariableVolume",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:VariableVolume;1"
           },
           {
             "enumValue": "ConstantVolume",
+            "displayName": {
+              "en": "Constant Volume"
+            },
             "name": "ConstantVolume",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:ConstantVolume;1"
           }
@@ -627,11 +723,17 @@
         "enumValues": [
           {
             "enumValue": "TwoPipe",
+            "displayName": {
+              "en": "Two-Pipe"
+            },
             "name": "TwoPipe",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:TwoPipe;1"
           },
           {
             "enumValue": "FourPipe",
+            "displayName": {
+              "en": "Four-Pipe"
+            },
             "name": "FourPipe",
             "@id": "dtmi:com:syyclops:AirHandlingUnit:FourPipe;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Condensing Unit/CondensingUnit.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Condensing Unit/CondensingUnit.json
@@ -22,11 +22,17 @@
         "enumValues": [
           {
             "enumValue": "WaterCooled",
+            "displayName": {
+              "en": "Water-cooled"
+            },
             "name": "WaterCooled",
             "@id": "dtmi:com:syyclops:CondensingUnit:WaterCooled;1"
           },
           {
             "enumValue": "AirCooled",
+            "displayName": {
+              "en": "Air-cooled"
+            },
             "name": "AirCooled",
             "@id": "dtmi:com:syyclops:CondensingUnit:AirCooled;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Damper/HVACDamper.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Damper/HVACDamper.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "Supply",
+            "displayName": {
+              "en": "Supply"
+            },
             "name": "Supply",
             "@id": "dtmi:com:syyclops:HVACDamper:Supply;1"
           },
           {
             "enumValue": "Return",
+            "displayName": {
+              "en": "Return"
+            },
             "name": "Return",
             "@id": "dtmi:com:syyclops:HVACDamper:Return;1"
           },
           {
             "enumValue": "Exhaust",
+            "displayName": {
+              "en": "Exhaust"
+            },
             "name": "Exhaust",
             "@id": "dtmi:com:syyclops:HVACDamper:Exhaust;1"
           }
@@ -53,16 +62,25 @@
         "enumValues": [
           {
             "enumValue": "III",
+            "displayName": {
+              "en": "Class III"
+            },
             "name": "III",
             "@id": "dtmi:com:syyclops:HVACDamper:III;1"
           },
           {
             "enumValue": "II",
+            "displayName": {
+              "en": "Class II"
+            },
             "name": "II",
             "@id": "dtmi:com:syyclops:HVACDamper:II;1"
           },
           {
             "enumValue": "I",
+            "displayName": {
+              "en": "Class I"
+            },
             "name": "I",
             "@id": "dtmi:com:syyclops:HVACDamper:I;1"
           }
@@ -87,16 +105,25 @@
         "enumValues": [
           {
             "enumValue": "Vee",
+            "displayName": {
+              "en": "Vee"
+            },
             "name": "Vee",
             "@id": "dtmi:com:syyclops:HVACDamper:Vee;1"
           },
           {
             "enumValue": "Round",
+            "displayName": {
+              "en": "Round"
+            },
             "name": "Round",
             "@id": "dtmi:com:syyclops:HVACDamper:Round;1"
           },
           {
             "enumValue": "Airfoil",
+            "displayName": {
+              "en": "Airfoil"
+            },
             "name": "Airfoil",
             "@id": "dtmi:com:syyclops:HVACDamper:Airfoil;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Heat Exchanger/HeatExchanger.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Heat Exchanger/HeatExchanger.json
@@ -22,26 +22,41 @@
         "enumValues": [
           {
             "enumValue": "Steam",
+            "displayName": {
+              "en": "Steam"
+            },
             "name": "Steam",
             "@id": "dtmi:com:syyclops:HeatExchanger:Steam;1"
           },
           {
             "enumValue": "SteamCondensate",
+            "displayName": {
+              "en": "Steam Condensate"
+            },
             "name": "SteamCondensate",
             "@id": "dtmi:com:syyclops:HeatExchanger:SteamCondensate;1"
           },
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:HotWater;1"
           },
           {
             "enumValue": "CondenserWater",
+            "displayName": {
+              "en": "Condenser Water"
+            },
             "name": "CondenserWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:CondenserWater;1"
           },
           {
             "enumValue": "ChilledWater",
+            "displayName": {
+              "en": "Chilled Water"
+            },
             "name": "ChilledWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:ChilledWater;1"
           }
@@ -66,21 +81,33 @@
         "enumValues": [
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:EE3;1"
           },
           {
             "enumValue": "SteamCondensate",
+            "displayName": {
+              "en": "Steam Condensate"
+            },
             "name": "SteamCondensate",
             "@id": "dtmi:com:syyclops:HeatExchanger:EE4;1"
           },
           {
             "enumValue": "CondenserWater",
+            "displayName": {
+              "en": "Condenser Water"
+            },
             "name": "CondenserWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:EE5;1"
           },
           {
             "enumValue": "ChilledWater",
+            "displayName": {
+              "en": "Chilled Water"
+            },
             "name": "ChilledWater",
             "@id": "dtmi:com:syyclops:HeatExchanger:EE6;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/Chilled Beam/ChilledBeam.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/Chilled Beam/ChilledBeam.json
@@ -106,11 +106,17 @@
         "enumValues": [
           {
             "enumValue": "TwoPipe",
+            "displayName": {
+              "en": "Two-Pipe"
+            },
             "name": "TwoPipe",
             "@id": "dtmi:com:syyclops:ChilledBeam:TwoPipe;1"
           },
           {
             "enumValue": "FourPipe",
+            "displayName": {
+              "en": "Four-Pipe"
+            },
             "name": "FourPipe",
             "@id": "dtmi:com:syyclops:ChilledBeam:FourPipe;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/Fan Coil Unit/FanCoilUnit.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/Fan Coil Unit/FanCoilUnit.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "vertical",
+            "displayName": {
+              "en": "Vertical"
+            },
             "name": "vertical",
             "@id": "dtmi:com:syyclops:FanCoilUnit:vertical;1"
           },
           {
             "enumValue": "horizontal",
+            "displayName": {
+              "en": "Horizontal"
+            },
             "name": "horizontal",
             "@id": "dtmi:com:syyclops:FanCoilUnit:horizontal;1"
           }
@@ -133,16 +139,25 @@
         "enumValues": [
           {
             "enumValue": "wall",
+            "displayName": {
+              "en": "Wall"
+            },
             "name": "wall",
             "@id": "dtmi:com:syyclops:FanCoilUnit:wall;1"
           },
           {
             "enumValue": "floor",
+            "displayName": {
+              "en": "Floor"
+            },
             "name": "floor",
             "@id": "dtmi:com:syyclops:FanCoilUnit:floor;1"
           },
           {
             "enumValue": "ceiling",
+            "displayName": {
+              "en": "Ceiling"
+            },
             "name": "ceiling",
             "@id": "dtmi:com:syyclops:FanCoilUnit:ceiling;1"
           }
@@ -207,11 +222,17 @@
         "enumValues": [
           {
             "enumValue": "TwoPipe",
+            "displayName": {
+              "en": "Two-Pipe"
+            },
             "name": "TwoPipe",
             "@id": "dtmi:com:syyclops:FanCoilUnit:TwoPipe;1"
           },
           {
             "enumValue": "FourPipe",
+            "displayName": {
+              "en": "Four-Pipe"
+            },
             "name": "FourPipe",
             "@id": "dtmi:com:syyclops:FanCoilUnit:FourPipe;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/VAV Box/FanPoweredBox/FanPoweredBox.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Terminal Unit/VAV Box/FanPoweredBox/FanPoweredBox.json
@@ -22,11 +22,17 @@
         "enumValues": [
           {
             "enumValue": "series",
+            "displayName": {
+              "en": "Series"
+            },
             "name": "series",
             "@id": "dtmi:com:syyclops:FanPoweredBox:series;1"
           },
           {
             "enumValue": "parallel",
+            "displayName": {
+              "en": "Parallel"
+            },
             "name": "parallel",
             "@id": "dtmi:com:syyclops:FanPoweredBox:parallel;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Unit Heater/UnitHeater.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Unit Heater/UnitHeater.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "vertical",
+            "displayName": {
+              "en": "Vertical"
+            },
             "name": "vertical",
             "@id": "dtmi:com:syyclops:UnitHeater:vertical;1"
           },
           {
             "enumValue": "horizontal",
+            "displayName": {
+              "en": "Horizontal"
+            },
             "name": "horizontal",
             "@id": "dtmi:com:syyclops:UnitHeater:horizontal;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Valve/HVACShutOffValve.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Valve/HVACShutOffValve.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "Gate",
+            "displayName": {
+              "en": "Gate"
+            },
             "name": "Gate",
             "@id": "dtmi:com:syyclops:HVACShutOffValve:Gate;1"
           },
           {
             "enumValue": "Butterfly",
+            "displayName": {
+              "en": "Butterfly"
+            },
             "name": "Butterfly",
             "@id": "dtmi:com:syyclops:HVACShutOffValve:Butterfly;1"
           },
           {
             "enumValue": "Ball",
+            "displayName": {
+              "en": "Ball"
+            },
             "name": "Ball",
             "@id": "dtmi:com:syyclops:HVACShutOffValve:Ball;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/HVAC/Ventilation Hood/Fume Hood/FumeHood.json
+++ b/Ontology/Syyclops/Asset/Equipment/HVAC/Ventilation Hood/Fume Hood/FumeHood.json
@@ -54,16 +54,25 @@
         "enumValues": [
           {
             "enumValue": "Horizontal",
+            "displayName": {
+              "en": "Horizontal"
+            },
             "name": "Horizontal",
             "@id": "dtmi:com:syyclops:FumeHood:Horizontal;1"
           },
           {
             "enumValue": "Vertical",
+            "displayName": {
+              "en": "Vertical"
+            },
             "name": "Vertical",
             "@id": "dtmi:com:syyclops:FumeHood:Vertical;1"
           },
           {
             "enumValue": "Combination",
+            "displayName": {
+              "en": "Combination"
+            },
             "name": "Combination",
             "@id": "dtmi:com:syyclops:FumeHood:Combination;1"
           }
@@ -88,11 +97,17 @@
         "enumValues": [
           {
             "enumValue": "Open",
+            "displayName": {
+              "en": "Open"
+            },
             "name": "Open",
             "@id": "dtmi:com:syyclops:FumeHood:Open;1"
           },
           {
             "enumValue": "Restricted",
+            "displayName": {
+              "en": "Restricted"
+            },
             "name": "Restricted",
             "@id": "dtmi:com:syyclops:FumeHood:Restricted;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/ICT/Data Network/WirelessAccessPoint.json
+++ b/Ontology/Syyclops/Asset/Equipment/ICT/Data Network/WirelessAccessPoint.json
@@ -19,21 +19,33 @@
         "enumValues": [
           {
             "enumValue": "WiFi7",
+            "displayName": {
+              "en": "Wi-Fi 7"
+            },
             "name": "WiFi7",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:WiFi7;1"
           },
           {
             "enumValue": "WiFi6",
+            "displayName": {
+              "en": "Wi-Fi 6"
+            },
             "name": "WiFi6",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:WiFi6;1"
           },
           {
             "enumValue": "WiFi5",
+            "displayName": {
+              "en": "Wi-Fi 5"
+            },
             "name": "WiFi5",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:WiFi5;1"
           },
           {
             "enumValue": "WiFi4",
+            "displayName": {
+              "en": "Wi-Fi 4"
+            },
             "name": "WiFi4",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:WiFi4;1"
           }
@@ -58,11 +70,17 @@
         "enumValues": [
           {
             "enumValue": "Outdoor",
+            "displayName": {
+              "en": "Outdoor"
+            },
             "name": "Outdoor",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:Outdoor;1"
           },
           {
             "enumValue": "Indoor",
+            "displayName": {
+              "en": "Indoor"
+            },
             "name": "Indoor",
             "@id": "dtmi:com:syyclops:WirelessAccessPoint:Indoor;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/ICT/Rack/ITRack.json
+++ b/Ontology/Syyclops/Asset/Equipment/ICT/Rack/ITRack.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "TwoPost",
+            "displayName": {
+              "en": "Two-Post"
+            },
             "name": "TwoPost",
             "@id": "dtmi:com:syyclops:ITRack:TwoPost;1"
           },
           {
             "enumValue": "FourPost",
+            "displayName": {
+              "en": "Four-Post"
+            },
             "name": "FourPost",
             "@id": "dtmi:com:syyclops:ITRack:FourPost;1"
           },
           {
             "enumValue": "Cabinet",
+            "displayName": {
+              "en": "Cabinet"
+            },
             "name": "Cabinet",
             "@id": "dtmi:com:syyclops:ITRack:Cabinet;1"
           }
@@ -53,11 +62,17 @@
         "enumValues": [
           {
             "enumValue": "Wall",
+            "displayName": {
+              "en": "Wall"
+            },
             "name": "Wall",
             "@id": "dtmi:com:syyclops:ITRack:Wall;1"
           },
           {
             "enumValue": "Floor",
+            "displayName": {
+              "en": "Floor"
+            },
             "name": "Floor",
             "@id": "dtmi:com:syyclops:ITRack:Floor;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Lighting/Luminaire/Luminaire.json
+++ b/Ontology/Syyclops/Asset/Equipment/Lighting/Luminaire/Luminaire.json
@@ -36,26 +36,41 @@
         "enumValues": [
           {
             "enumValue": "WallMount",
+            "displayName": {
+              "en": "Wall Mount"
+            },
             "name": "WallMount",
             "@id": "dtmi:com:syyclops:Luminaire:WallMount;1"
           },
           {
             "enumValue": "Recessed",
+            "displayName": {
+              "en": "Recessed"
+            },
             "name": "Recessed",
             "@id": "dtmi:com:syyclops:Luminaire:Recessed;1"
           },
           {
             "enumValue": "Pendant",
+            "displayName": {
+              "en": "Pendant"
+            },
             "name": "Pendant",
             "@id": "dtmi:com:syyclops:Luminaire:Pendant;1"
           },
           {
             "enumValue": "Track",
+            "displayName": {
+              "en": "Track"
+            },
             "name": "Track",
             "@id": "dtmi:com:syyclops:Luminaire:Track;1"
           },
           {
             "enumValue": "Ground",
+            "displayName": {
+              "en": "Ground"
+            },
             "name": "Ground",
             "@id": "dtmi:com:syyclops:Luminaire:Ground;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Meter/ElectricalMeter.json
+++ b/Ontology/Syyclops/Asset/Equipment/Meter/ElectricalMeter.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "DC",
+            "displayName": {
+              "en": "DC"
+            },
             "name": "DC",
             "@id": "dtmi:com:syyclops:ElectricalMeter:DC;1"
           },
           {
             "enumValue": "AC",
+            "displayName": {
+              "en": "AC"
+            },
             "name": "AC",
             "@id": "dtmi:com:syyclops:ElectricalMeter:AC;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Boiler/Boiler.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Boiler/Boiler.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "WaterTube",
+            "displayName": {
+              "en": "Water Tube"
+            },
             "name": "WaterTube",
             "@id": "dtmi:com:syyclops:Boiler:WaterTube;1"
           },
           {
             "enumValue": "FireTube",
+            "displayName": {
+              "en": "Fire Tube"
+            },
             "name": "FireTube",
             "@id": "dtmi:com:syyclops:Boiler:FireTube;1"
           }
@@ -156,11 +162,17 @@
         "enumValues": [
           {
             "enumValue": "Steam",
+            "displayName": {
+              "en": "Steam"
+            },
             "name": "Steam",
             "@id": "dtmi:com:syyclops:Boiler:Steam;1"
           },
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:Boiler:HotWater;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Faucet/Faucet.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Faucet/Faucet.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "Touchless",
+            "displayName": {
+              "en": "Touchless"
+            },
             "name": "Touchless",
             "@id": "dtmi:com:syyclops:Faucet:Touchless;1"
           },
           {
             "enumValue": "ManualOnly",
+            "displayName": {
+              "en": "Manual Only"
+            },
             "name": "ManualOnly",
             "@id": "dtmi:com:syyclops:Faucet:ManualOnly;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/FlushometerValve.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/FlushometerValve.json
@@ -55,11 +55,17 @@
         "enumValues": [
           {
             "enumValue": "Touchless",
+            "displayName": {
+              "en": "Touchless"
+            },
             "name": "Touchless",
             "@id": "dtmi:com:syyclops:FlushometerValve:Touchless;1"
           },
           {
             "enumValue": "ManualOnly",
+            "displayName": {
+              "en": "Manual Only"
+            },
             "name": "ManualOnly",
             "@id": "dtmi:com:syyclops:FlushometerValve:ManualOnly;1"
           }
@@ -84,11 +90,17 @@
         "enumValues": [
           {
             "enumValue": "Piston",
+            "displayName": {
+              "en": "Piston"
+            },
             "name": "Piston",
             "@id": "dtmi:com:syyclops:FlushometerValve:Piston;1"
           },
           {
             "enumValue": "Diaphragm",
+            "displayName": {
+              "en": "Diaphragm"
+            },
             "name": "Diaphragm",
             "@id": "dtmi:com:syyclops:FlushometerValve:Diaphragm;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Toilet/Toilet.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Toilet/Toilet.json
@@ -55,11 +55,17 @@
         "enumValues": [
           {
             "enumValue": "WallMounted",
+            "displayName": {
+              "en": "Wall Mounted"
+            },
             "name": "WallMounted",
             "@id": "dtmi:com:syyclops:Toilet:WallMounted;1"
           },
           {
             "enumValue": "FloorMounted",
+            "displayName": {
+              "en": "Floor Mounted"
+            },
             "name": "FloorMounted",
             "@id": "dtmi:com:syyclops:Toilet:FloorMounted;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Toilet/ToiletTank.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Fixture/Toilet/ToiletTank.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "PressureAssisted",
+            "displayName": {
+              "en": "Pressure Assisted"
+            },
             "name": "PressureAssisted",
             "@id": "dtmi:com:syyclops:ToiletTank:PressureAssisted;1"
           },
           {
             "enumValue": "Gravity",
+            "displayName": {
+              "en": "Gravity"
+            },
             "name": "Gravity",
             "@id": "dtmi:com:syyclops:ToiletTank:Gravity;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Tank/PlumbingExpansionTank.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Tank/PlumbingExpansionTank.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "Diaphragm",
+            "displayName": {
+              "en": "Diaphragm"
+            },
             "name": "Diaphragm",
             "@id": "dtmi:com:syyclops:PlumbingExpansionTank:Diaphragm;1"
           },
           {
             "enumValue": "Compression",
+            "displayName": {
+              "en": "Compression"
+            },
             "name": "Compression",
             "@id": "dtmi:com:syyclops:PlumbingExpansionTank:Compression;1"
           },
           {
             "enumValue": "Bladder",
+            "displayName": {
+              "en": "Bladder"
+            },
             "name": "Bladder",
             "@id": "dtmi:com:syyclops:PlumbingExpansionTank:Bladder;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Tank/PlumbingStorageTank.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Plumbing Tank/PlumbingStorageTank.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:PlumbingStorageTank:HotWater;1"
           },
           {
             "enumValue": "ChilledWater",
+            "displayName": {
+              "en": "Chilled Water"
+            },
             "name": "ChilledWater",
             "@id": "dtmi:com:syyclops:PlumbingStorageTank:ChilledWater;1"
           }
@@ -48,11 +54,17 @@
         "enumValues": [
           {
             "enumValue": "Vertical",
+            "displayName": {
+              "en": "Vertical"
+            },
             "name": "Vertical",
             "@id": "dtmi:com:syyclops:PlumbingStorageTank:Vertical;1"
           },
           {
             "enumValue": "Horizontal",
+            "displayName": {
+              "en": "Horizontal"
+            },
             "name": "Horizontal",
             "@id": "dtmi:com:syyclops:PlumbingStorageTank:Horizontal;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Plumbing/Valve/PlumbingShutOffValve.json
+++ b/Ontology/Syyclops/Asset/Equipment/Plumbing/Valve/PlumbingShutOffValve.json
@@ -19,16 +19,25 @@
         "enumValues": [
           {
             "enumValue": "Gate",
+            "displayName": {
+              "en": "Gate"
+            },
             "name": "Gate",
             "@id": "dtmi:com:syyclops:PlumbingShutOffValve:Gate;1"
           },
           {
             "enumValue": "Butterfly",
+            "displayName": {
+              "en": "Butterfly"
+            },
             "name": "Butterfly",
             "@id": "dtmi:com:syyclops:PlumbingShutOffValve:Butterfly;1"
           },
           {
             "enumValue": "Ball",
+            "displayName": {
+              "en": "Ball"
+            },
             "name": "Ball",
             "@id": "dtmi:com:syyclops:PlumbingShutOffValve:Ball;1"
           }

--- a/Ontology/Syyclops/Asset/Equipment/Refrigeration/DefrostEquipment.json
+++ b/Ontology/Syyclops/Asset/Equipment/Refrigeration/DefrostEquipment.json
@@ -20,6 +20,9 @@
         "enumValues": [
           {
             "enumValue": "Off Cycle",
+            "displayName": {
+              "en": "Off-Cycle"
+            },
             "name": "OffCycle",
             "description": {
               "en": "Defrost takes place by turning off the compressor and evaporator fan, and waiting a period of time."
@@ -28,6 +31,9 @@
           },
           {
             "enumValue": "Electric",
+            "displayName": {
+              "en": "Electric"
+            },
             "name": "Electric",
             "description": {
               "en": "Defrost takes place by turning off the compressor and evaporator fan, and enabling an electric heating element for a period of time."
@@ -36,6 +42,9 @@
           },
           {
             "enumValue": "Hot Gas",
+            "displayName": {
+              "en": "Hot Gas"
+            },
             "name": "HotGas",
             "description": {
               "en": "Defrost takes place by turning off the evaporator fan, operating a reversing valve in the refrigeration circuit, and deliverying hot refrigrant gas to the evaporator coil for a period of time."
@@ -44,6 +53,9 @@
           },
           {
             "enumValue": "Reverse Air",
+            "displayName": {
+              "en": "Reverse Air"
+            },
             "name": "ReverseAir",
             "description": {
               "en": "Defrost takes place by turning off the compressor, and running the evaporator fan in reverse for a period of time."
@@ -173,16 +185,25 @@
         "enumValues": [
           {
             "enumValue": "Interval Timer",
+            "displayName": {
+              "en": "Interval Timer"
+            },
             "name": "IntervalTimer",
             "@id": "dtmi:com:syyclops:DefrostEquipment:IntervalTimer;1"
           },
           {
             "enumValue": "Schedule",
+            "displayName": {
+              "en": "Schedule"
+            },
             "name": "Schedule",
             "@id": "dtmi:com:syyclops:DefrostEquipment:Schedule;1"
           },
           {
             "enumValue": "Adaptive",
+            "displayName": {
+              "en": "Adaptive"
+            },
             "name": "Adaptive",
             "@id": "dtmi:com:syyclops:DefrostEquipment:Adaptive;1"
           }
@@ -207,16 +228,25 @@
         "enumValues": [
           {
             "enumValue": "Time",
+            "displayName": {
+              "en": "Time"
+            },
             "name": "Time",
             "@id": "dtmi:com:syyclops:DefrostEquipment:Time;1"
           },
           {
             "enumValue": "Termination Temperature",
+            "displayName": {
+              "en": "Termination Temperature"
+            },
             "name": "TerminationTemperature",
             "@id": "dtmi:com:syyclops:DefrostEquipment:TerminationTemperature;1"
           },
           {
             "enumValue": "Adaptive",
+            "displayName": {
+              "en": "Adaptive"
+            },
             "name": "Adaptive",
             "@id": "dtmi:com:syyclops:DefrostEquipment:EE4;1"
           }

--- a/Ontology/Syyclops/Building Component/BuildingComponent.json
+++ b/Ontology/Syyclops/Building Component/BuildingComponent.json
@@ -394,6 +394,9 @@
       "enumValues": [
         {
           "enumValue": "MakeupWater",
+          "displayName": {
+            "en": "Makeup Water"
+          },
           "name": "MakeupWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:MakeupWater;1",
           "description": {
@@ -402,6 +405,9 @@
         },
         {
           "enumValue": "Light",
+          "displayName": {
+            "en": "Light"
+          },
           "name": "Light",
           "@id": "dtmi:com:syyclops:BuildingComponent:Light;1",
           "description": {
@@ -410,6 +416,9 @@
         },
         {
           "enumValue": "IrrigationWater",
+          "displayName": {
+            "en": "Irrigation Water"
+          },
           "name": "IrrigationWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:IrrigationWater;1",
           "description": {
@@ -418,6 +427,9 @@
         },
         {
           "enumValue": "HotWater",
+          "displayName": {
+            "en": "Hot Water"
+          },
           "name": "HotWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:HotWater;1",
           "description": {
@@ -426,6 +438,9 @@
         },
         {
           "enumValue": "HotDomesticWater",
+          "displayName": {
+            "en": "Hot Domestic Water"
+          },
           "name": "HotDomesticWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:HotDomesticWater;1",
           "description": {
@@ -434,6 +449,9 @@
         },
         {
           "enumValue": "GreaseExhaustAir",
+          "displayName": {
+            "en": "Grease Exhaust Air"
+          },
           "name": "GreaseExhaustAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:GreaseExhaustAir;1",
           "description": {
@@ -442,6 +460,9 @@
         },
         {
           "enumValue": "Gasoline",
+          "displayName": {
+            "en": "Gasoline"
+          },
           "name": "Gasoline",
           "@id": "dtmi:com:syyclops:BuildingComponent:Gasoline;1",
           "description": {
@@ -450,6 +471,9 @@
         },
         {
           "enumValue": "FuelOil",
+          "displayName": {
+            "en": "Fuel Oil"
+          },
           "name": "FuelOil",
           "@id": "dtmi:com:syyclops:BuildingComponent:FuelOil;1",
           "description": {
@@ -458,6 +482,9 @@
         },
         {
           "enumValue": "Freight",
+          "displayName": {
+            "en": "Freight"
+          },
           "name": "Freight",
           "@id": "dtmi:com:syyclops:BuildingComponent:Freight;1",
           "description": {
@@ -466,6 +493,9 @@
         },
         {
           "enumValue": "ExhaustAir",
+          "displayName": {
+            "en": "Exhaust Air"
+          },
           "name": "ExhaustAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:ExhaustAir;1",
           "description": {
@@ -474,6 +504,9 @@
         },
         {
           "enumValue": "Ethernet",
+          "displayName": {
+            "en": "Ethernet"
+          },
           "name": "Ethernet",
           "@id": "dtmi:com:syyclops:BuildingComponent:Ethernet;1",
           "description": {
@@ -482,6 +515,9 @@
         },
         {
           "enumValue": "DriveElec",
+          "displayName": {
+            "en": "Drive Electricity"
+          },
           "name": "DriveElec",
           "@id": "dtmi:com:syyclops:BuildingComponent:DriveElec;1",
           "description": {
@@ -490,6 +526,9 @@
         },
         {
           "enumValue": "Diesel",
+          "displayName": {
+            "en": "Diesel"
+          },
           "name": "Diesel",
           "@id": "dtmi:com:syyclops:BuildingComponent:Diesel;1",
           "description": {
@@ -498,6 +537,9 @@
         },
         {
           "enumValue": "DCElec",
+          "displayName": {
+            "en": "DC Electricity"
+          },
           "name": "DCElec",
           "@id": "dtmi:com:syyclops:BuildingComponent:DCElec;1",
           "description": {
@@ -506,6 +548,9 @@
         },
         {
           "enumValue": "CondenserWater",
+          "displayName": {
+            "en": "Condenser Water"
+          },
           "name": "CondenserWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:CondenserWater;1",
           "description": {
@@ -514,6 +559,9 @@
         },
         {
           "enumValue": "Condensate",
+          "displayName": {
+            "en": "Condensate"
+          },
           "name": "Condensate",
           "@id": "dtmi:com:syyclops:BuildingComponent:Condensate;1",
           "description": {
@@ -522,6 +570,9 @@
         },
         {
           "enumValue": "ColdDomesticWater",
+          "displayName": {
+            "en": "Cold Domestic Water"
+          },
           "name": "ColdDomesticWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:ColdDomesticWater;1",
           "description": {
@@ -530,6 +581,9 @@
         },
         {
           "enumValue": "ChilledWater",
+          "displayName": {
+            "en": "Chilled Water"
+          },
           "name": "ChilledWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:ChilledWater;1",
           "description": {
@@ -538,6 +592,9 @@
         },
         {
           "enumValue": "BlowdownWater",
+          "displayName": {
+            "en": "Blowdown Water"
+          },
           "name": "BlowdownWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:BlowdownWater;1",
           "description": {
@@ -546,6 +603,9 @@
         },
         {
           "enumValue": "Air",
+          "displayName": {
+            "en": "Air"
+          },
           "name": "Air",
           "@id": "dtmi:com:syyclops:BuildingComponent:Air;1",
           "description": {
@@ -554,6 +614,9 @@
         },
         {
           "enumValue": "ACElec",
+          "displayName": {
+            "en": "AC Electricity"
+          },
           "name": "ACElec",
           "@id": "dtmi:com:syyclops:BuildingComponent:ACElec;1",
           "description": {
@@ -562,6 +625,9 @@
         },
         {
           "enumValue": "NaturalGas",
+          "displayName": {
+            "en": "Natural Gas"
+          },
           "name": "NaturalGas",
           "@id": "dtmi:com:syyclops:BuildingComponent:NaturalGas;1",
           "description": {
@@ -570,6 +636,9 @@
         },
         {
           "enumValue": "NonPotableDomesticWater",
+          "displayName": {
+            "en": "Non-Potable Domestic Water"
+          },
           "name": "NonPotableDomesticWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:NonPotableDomesticWater;1",
           "description": {
@@ -578,6 +647,9 @@
         },
         {
           "enumValue": "OutsideAir",
+          "displayName": {
+            "en": "Outside Air"
+          },
           "name": "OutsideAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:OutsideAir;1",
           "description": {
@@ -586,6 +658,9 @@
         },
         {
           "enumValue": "Propane",
+          "displayName": {
+            "en": "Propane"
+          },
           "name": "Propane",
           "@id": "dtmi:com:syyclops:BuildingComponent:Propane;1",
           "description": {
@@ -594,6 +669,9 @@
         },
         {
           "enumValue": "RecircHotDomesticWater",
+          "displayName": {
+            "en": "Recirculating Hot Domestic Water"
+          },
           "name": "RecircHotDomesticWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:RecircHotDomesticWater;1",
           "description": {
@@ -602,6 +680,9 @@
         },
         {
           "enumValue": "Refrig",
+          "displayName": {
+            "en": "Refrigerant"
+          },
           "name": "Refrig",
           "@id": "dtmi:com:syyclops:BuildingComponent:Refrig;1",
           "description": {
@@ -610,6 +691,9 @@
         },
         {
           "enumValue": "ReturnAir",
+          "displayName": {
+            "en": "Return Air"
+          },
           "name": "ReturnAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:ReturnAir;1",
           "description": {
@@ -618,6 +702,9 @@
         },
         {
           "enumValue": "SprinklerWater",
+          "displayName": {
+            "en": "Sprinkler Water"
+          },
           "name": "SprinklerWater",
           "@id": "dtmi:com:syyclops:BuildingComponent:SprinklerWater;1",
           "description": {
@@ -626,6 +713,9 @@
         },
         {
           "enumValue": "Steam",
+          "displayName": {
+            "en": "Steam"
+          },
           "name": "Steam",
           "@id": "dtmi:com:syyclops:BuildingComponent:Steam;1",
           "description": {
@@ -634,6 +724,9 @@
         },
         {
           "enumValue": "StormDrainage",
+          "displayName": {
+            "en": "Storm Drainage"
+          },
           "name": "StormDrainage",
           "@id": "dtmi:com:syyclops:BuildingComponent:StormDrainage;1",
           "description": {
@@ -642,6 +735,9 @@
         },
         {
           "enumValue": "SupplyAir",
+          "displayName": {
+            "en": "Supply Air"
+          },
           "name": "SupplyAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:SupplyAir;1",
           "description": {
@@ -650,6 +746,9 @@
         },
         {
           "enumValue": "TransferAir",
+          "displayName": {
+            "en": "Transfer Air"
+          },
           "name": "TransferAir",
           "@id": "dtmi:com:syyclops:BuildingComponent:TransferAir;1",
           "description": {
@@ -658,6 +757,9 @@
         },
         {
           "enumValue": "WasteVentDrainage",
+          "displayName": {
+            "en": "Waste Vent Drainage"
+          },
           "name": "WasteVentDrainage",
           "@id": "dtmi:com:syyclops:BuildingComponent:WasteVentDrainage;1",
           "description": {
@@ -666,6 +768,9 @@
         },
         {
           "enumValue": "Water",
+          "displayName": {
+            "en": "Water"
+          },
           "name": "Water",
           "@id": "dtmi:com:syyclops:BuildingComponent:Water;1",
           "description": {

--- a/Ontology/Syyclops/Collection/Asset Collection/AssetCollection.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/AssetCollection.json
@@ -39,6 +39,9 @@
       "enumValues": [
         {
           "enumValue": "MakeupWater",
+          "displayName": {
+            "en": "Makeup Water"
+          },
           "name": "MakeupWater",
           "@id": "dtmi:com:syyclops:AssetCollection:MakeupWater;1",
           "description": {
@@ -47,6 +50,9 @@
         },
         {
           "enumValue": "Light",
+          "displayName": {
+            "en": "Light"
+          },
           "name": "Light",
           "@id": "dtmi:com:syyclops:AssetCollection:Light;1",
           "description": {
@@ -55,6 +61,9 @@
         },
         {
           "enumValue": "IrrigationWater",
+          "displayName": {
+            "en": "Irrigation Water"
+          },
           "name": "IrrigationWater",
           "@id": "dtmi:com:syyclops:AssetCollection:IrrigationWater;1",
           "description": {
@@ -63,6 +72,9 @@
         },
         {
           "enumValue": "HotWater",
+          "displayName": {
+            "en": "Hot Water"
+          },
           "name": "HotWater",
           "@id": "dtmi:com:syyclops:AssetCollection:HotWater;1",
           "description": {
@@ -71,6 +83,9 @@
         },
         {
           "enumValue": "HotDomesticWater",
+          "displayName": {
+            "en": "Hot Domestic Water"
+          },
           "name": "HotDomesticWater",
           "@id": "dtmi:com:syyclops:AssetCollection:HotDomesticWater;1",
           "description": {
@@ -79,6 +94,9 @@
         },
         {
           "enumValue": "GreaseExhaustAir",
+          "displayName": {
+            "en": "Grease Exhaust Air"
+          },
           "name": "GreaseExhaustAir",
           "@id": "dtmi:com:syyclops:AssetCollection:GreaseExhaustAir;1",
           "description": {
@@ -87,6 +105,9 @@
         },
         {
           "enumValue": "Gasoline",
+          "displayName": {
+            "en": "Gasoline"
+          },
           "name": "Gasoline",
           "@id": "dtmi:com:syyclops:AssetCollection:Gasoline;1",
           "description": {
@@ -95,6 +116,9 @@
         },
         {
           "enumValue": "FuelOil",
+          "displayName": {
+            "en": "Fuel Oil"
+          },
           "name": "FuelOil",
           "@id": "dtmi:com:syyclops:AssetCollection:FuelOil;1",
           "description": {
@@ -103,6 +127,9 @@
         },
         {
           "enumValue": "Freight",
+          "displayName": {
+            "en": "Freight"
+          },
           "name": "Freight",
           "@id": "dtmi:com:syyclops:AssetCollection:Freight;1",
           "description": {
@@ -111,6 +138,9 @@
         },
         {
           "enumValue": "ExhaustAir",
+          "displayName": {
+            "en": "Exhaust Air"
+          },
           "name": "ExhaustAir",
           "@id": "dtmi:com:syyclops:AssetCollection:ExhaustAir;1",
           "description": {
@@ -119,6 +149,9 @@
         },
         {
           "enumValue": "Ethernet",
+          "displayName": {
+            "en": "Ethernet"
+          },
           "name": "Ethernet",
           "@id": "dtmi:com:syyclops:AssetCollection:Ethernet;1",
           "description": {
@@ -127,6 +160,9 @@
         },
         {
           "enumValue": "DriveElec",
+          "displayName": {
+            "en": "Drive Electricity"
+          },
           "name": "DriveElec",
           "@id": "dtmi:com:syyclops:AssetCollection:DriveElec;1",
           "description": {
@@ -135,6 +171,9 @@
         },
         {
           "enumValue": "Diesel",
+          "displayName": {
+            "en": "Diesel"
+          },
           "name": "Diesel",
           "@id": "dtmi:com:syyclops:AssetCollection:Diesel;1",
           "description": {
@@ -143,6 +182,9 @@
         },
         {
           "enumValue": "DCElec",
+          "displayName": {
+            "en": "DC Electricity"
+          },
           "name": "DCElec",
           "@id": "dtmi:com:syyclops:AssetCollection:DCElec;1",
           "description": {
@@ -151,6 +193,9 @@
         },
         {
           "enumValue": "CondenserWater",
+          "displayName": {
+            "en": "Condenser Water"
+          },
           "name": "CondenserWater",
           "@id": "dtmi:com:syyclops:AssetCollection:CondenserWater;1",
           "description": {
@@ -159,6 +204,9 @@
         },
         {
           "enumValue": "Condensate",
+          "displayName": {
+            "en": "Condensate"
+          },
           "name": "Condensate",
           "@id": "dtmi:com:syyclops:AssetCollection:Condensate;1",
           "description": {
@@ -167,6 +215,9 @@
         },
         {
           "enumValue": "ColdDomesticWater",
+          "displayName": {
+            "en": "Cold Domestic Water"
+          },
           "name": "ColdDomesticWater",
           "@id": "dtmi:com:syyclops:AssetCollection:ColdDomesticWater;1",
           "description": {
@@ -175,6 +226,9 @@
         },
         {
           "enumValue": "ChilledWater",
+          "displayName": {
+            "en": "Chilled Water"
+          },
           "name": "ChilledWater",
           "@id": "dtmi:com:syyclops:AssetCollection:ChilledWater;1",
           "description": {
@@ -183,6 +237,9 @@
         },
         {
           "enumValue": "BlowdownWater",
+          "displayName": {
+            "en": "Blowdown Water"
+          },
           "name": "BlowdownWater",
           "@id": "dtmi:com:syyclops:AssetCollection:BlowdownWater;1",
           "description": {
@@ -191,6 +248,9 @@
         },
         {
           "enumValue": "Air",
+          "displayName": {
+            "en": "Air"
+          },
           "name": "Air",
           "@id": "dtmi:com:syyclops:AssetCollection:Air;1",
           "description": {
@@ -199,6 +259,9 @@
         },
         {
           "enumValue": "ACElec",
+          "displayName": {
+            "en": "AC Electricity"
+          },
           "name": "ACElec",
           "@id": "dtmi:com:syyclops:AssetCollection:ACElec;1",
           "description": {
@@ -207,6 +270,9 @@
         },
         {
           "enumValue": "NaturalGas",
+          "displayName": {
+            "en": "Natural Gas"
+          },
           "name": "NaturalGas",
           "@id": "dtmi:com:syyclops:AssetCollection:NaturalGas;1",
           "description": {
@@ -215,6 +281,9 @@
         },
         {
           "enumValue": "NonPotableDomesticWater",
+          "displayName": {
+            "en": "Non-Potable Domestic Water"
+          },
           "name": "NonPotableDomesticWater",
           "@id": "dtmi:com:syyclops:AssetCollection:NonPotableDomesticWater;1",
           "description": {
@@ -223,6 +292,9 @@
         },
         {
           "enumValue": "OutsideAir",
+          "displayName": {
+            "en": "Outside Air"
+          },
           "name": "OutsideAir",
           "@id": "dtmi:com:syyclops:AssetCollection:OutsideAir;1",
           "description": {
@@ -231,6 +303,9 @@
         },
         {
           "enumValue": "People",
+          "displayName": {
+            "en": "People"
+          },
           "name": "People",
           "@id": "dtmi:com:syyclops:AssetCollection:People;1",
           "description": {
@@ -239,6 +314,9 @@
         },
         {
           "enumValue": "RecircHotDomesticWater",
+          "displayName": {
+            "en": "Recirculating Hot Domestic Water"
+          },
           "name": "RecircHotDomesticWater",
           "@id": "dtmi:com:syyclops:AssetCollection:RecircHotDomesticWater;1",
           "description": {
@@ -247,6 +325,9 @@
         },
         {
           "enumValue": "Refrig",
+          "displayName": {
+            "en": "Refrigerant"
+          },
           "name": "Refrig",
           "@id": "dtmi:com:syyclops:AssetCollection:Refrig;1",
           "description": {
@@ -255,6 +336,9 @@
         },
         {
           "enumValue": "ReturnAir",
+          "displayName": {
+            "en": "Return Air"
+          },
           "name": "ReturnAir",
           "@id": "dtmi:com:syyclops:AssetCollection:ReturnAir;1",
           "description": {
@@ -263,6 +347,9 @@
         },
         {
           "enumValue": "SprinklerWater",
+          "displayName": {
+            "en": "Sprinkler Water"
+          },
           "name": "SprinklerWater",
           "@id": "dtmi:com:syyclops:AssetCollection:SprinklerWater;1",
           "description": {
@@ -271,6 +358,9 @@
         },
         {
           "enumValue": "Steam",
+          "displayName": {
+            "en": "Steam"
+          },
           "name": "Steam",
           "@id": "dtmi:com:syyclops:AssetCollection:Steam;1",
           "description": {
@@ -279,6 +369,9 @@
         },
         {
           "enumValue": "StormDrainage",
+          "displayName": {
+            "en": "Storm Drainage"
+          },
           "name": "StormDrainage",
           "@id": "dtmi:com:syyclops:AssetCollection:StormDrainage;1",
           "description": {
@@ -287,6 +380,9 @@
         },
         {
           "enumValue": "SupplyAir",
+          "displayName": {
+            "en": "Supply Air"
+          },
           "name": "SupplyAir",
           "@id": "dtmi:com:syyclops:AssetCollection:SupplyAir;1",
           "description": {
@@ -295,6 +391,9 @@
         },
         {
           "enumValue": "TransferAir",
+          "displayName": {
+            "en": "Transfer Air"
+          },
           "name": "TransferAir",
           "@id": "dtmi:com:syyclops:AssetCollection:TransferAir;1",
           "description": {
@@ -303,6 +402,9 @@
         },
         {
           "enumValue": "WasteVentDrainage",
+          "displayName": {
+            "en": "Waste Vent Drainage"
+          },
           "name": "WasteVentDrainage",
           "@id": "dtmi:com:syyclops:AssetCollection:WasteVentDrainage;1",
           "description": {
@@ -311,6 +413,9 @@
         },
         {
           "enumValue": "Water",
+          "displayName": {
+            "en": "Water"
+          },
           "name": "Water",
           "@id": "dtmi:com:syyclops:AssetCollection:Water;1",
           "description": {

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit.json
@@ -38,19 +38,25 @@
         "enumValues": [
           {
             "name": "One",
-            "displayName": "1",
+            "displayName": {
+              "en": "1"
+            },
             "enumValue": "1",
             "@id": "dtmi:com:syyclops:ElectricalCircuit:One;1"
           },
           {
             "name": "Two",
-            "displayName": "2",
+            "displayName": {
+              "en": "2"
+            },
             "enumValue": "2",
             "@id": "dtmi:com:syyclops:ElectricalCircuit:Two;1"
           },
           {
             "name": "Three",
-            "displayName": "3",
+            "displayName": {
+              "en": "3"
+            },
             "enumValue": "3",
             "@id": "dtmi:com:syyclops:ElectricalCircuit:Three;1"
           }

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit1Pole.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit1Pole.json
@@ -21,19 +21,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit1Pole:A;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit1Pole:B;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit1Pole:C;1"
           }

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit2Pole.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit2Pole.json
@@ -21,19 +21,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:A;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:B;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:C;1"
           }
@@ -58,19 +64,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:EE3;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:EE4;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit2Pole:EE5;1"
           }

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit3Pole.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/Electrical/Electrical Circuit/ElectricalCircuit3Pole.json
@@ -21,19 +21,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:A;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:B;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:C;1"
           }
@@ -58,19 +64,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE3;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE4;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE5;1"
           }
@@ -95,19 +107,25 @@
         "enumValues": [
           {
             "name": "A",
-            "displayName": "A",
+            "displayName": {
+              "en": "A"
+            },
             "enumValue": "A",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE7;1"
           },
           {
             "name": "B",
-            "displayName": "B",
+            "displayName": {
+              "en": "B"
+            },
             "enumValue": "B",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE8;1"
           },
           {
             "name": "C",
-            "displayName": "C",
+            "displayName": {
+              "en": "C"
+            },
             "enumValue": "C",
             "@id": "dtmi:com:syyclops:ElectricalCircuit3Pole:EE9;1"
           }

--- a/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/System.json
+++ b/Ontology/Syyclops/Collection/Asset Collection/Equipment/System/System.json
@@ -32,26 +32,41 @@
         "enumValues": [
           {
             "enumValue": "Utility",
+            "displayName": {
+              "en": "Utility"
+            },
             "name": "Utility",
             "@id": "dtmi:com:syyclops:System:Utility;1"
           },
           {
             "enumValue": "Tenant",
+            "displayName": {
+              "en": "Tenant"
+            },
             "name": "Tenant",
             "@id": "dtmi:com:syyclops:System:Tenant;1"
           },
           {
             "enumValue": "Site",
+            "displayName": {
+              "en": "Site"
+            },
             "name": "Site",
             "@id": "dtmi:com:syyclops:System:Site;1"
           },
           {
             "enumValue": "District",
+            "displayName": {
+              "en": "District"
+            },
             "name": "District",
             "@id": "dtmi:com:syyclops:System:District;1"
           },
           {
             "enumValue": "Building",
+            "displayName": {
+              "en": "Building"
+            },
             "name": "Building",
             "@id": "dtmi:com:syyclops:System:Building;1"
           }

--- a/Ontology/Syyclops/Component/Asset/DuctConnection.json
+++ b/Ontology/Syyclops/Component/Asset/DuctConnection.json
@@ -55,16 +55,25 @@
         "enumValues": [
           {
             "enumValue": "round",
+            "displayName": {
+              "en": "Round"
+            },
             "name": "round",
             "@id": "dtmi:com:syyclops:DuctConnection:round;1"
           },
           {
             "enumValue": "rectangle",
+            "displayName": {
+              "en": "Rectangle"
+            },
             "name": "rectangle",
             "@id": "dtmi:com:syyclops:DuctConnection:rectangle;1"
           },
           {
             "enumValue": "oval",
+            "displayName": {
+              "en": "Oval"
+            },
             "name": "oval",
             "@id": "dtmi:com:syyclops:DuctConnection:oval;1"
           }
@@ -89,11 +98,17 @@
         "enumValues": [
           {
             "enumValue": "single",
+            "displayName": {
+              "en": "Single"
+            },
             "name": "single",
             "@id": "dtmi:com:syyclops:DuctConnection:single;1"
           },
           {
             "enumValue": "dual",
+            "displayName": {
+              "en": "Dual"
+            },
             "name": "dual",
             "@id": "dtmi:com:syyclops:DuctConnection:dual;1"
           }

--- a/Ontology/Syyclops/Component/Asset/ElectricalBus.json
+++ b/Ontology/Syyclops/Component/Asset/ElectricalBus.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "Copper",
+            "displayName": {
+              "en": "Copper"
+            },
             "name": "Copper",
             "@id": "dtmi:com:syyclops:ElectricalBus:Copper;1"
           },
           {
             "enumValue": "Aluminium",
+            "displayName": {
+              "en": "Aluminium"
+            },
             "name": "Aluminium",
             "@id": "dtmi:com:syyclops:ElectricalBus:Aluminium;1"
           }

--- a/Ontology/Syyclops/Component/Asset/HVACCoolingMethod.json
+++ b/Ontology/Syyclops/Component/Asset/HVACCoolingMethod.json
@@ -19,11 +19,17 @@
         "enumValues": [
           {
             "enumValue": "DX",
+            "displayName": {
+              "en": "DX (Direct Expansion)"
+            },
             "name": "DX",
             "@id": "dtmi:com:syyclops:HVACCoolingMethod:DX;1"
           },
           {
             "enumValue": "ChilledWater",
+            "displayName": {
+              "en": "Chilled Water"
+            },
             "name": "ChilledWater",
             "@id": "dtmi:com:syyclops:HVACCoolingMethod:ChilledWater;1"
           }

--- a/Ontology/Syyclops/Component/Asset/HVACHeatingMethod.json
+++ b/Ontology/Syyclops/Component/Asset/HVACHeatingMethod.json
@@ -19,21 +19,33 @@
         "enumValues": [
           {
             "enumValue": "Steam",
+            "displayName": {
+              "en": "Steam"
+            },
             "name": "Steam",
             "@id": "dtmi:com:syyclops:HVACHeatingMethod:Steam;1"
           },
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:HVACHeatingMethod:HotWater;1"
           },
           {
             "enumValue": "Gas",
+            "displayName": {
+              "en": "Gas"
+            },
             "name": "Gas",
             "@id": "dtmi:com:syyclops:HVACHeatingMethod:Gas;1"
           },
           {
             "enumValue": "Electric",
+            "displayName": {
+              "en": "Electric"
+            },
             "name": "Electric",
             "@id": "dtmi:com:syyclops:HVACHeatingMethod:Electric;1"
           }

--- a/Ontology/Syyclops/Component/Capability/CapabilityCommunication.json
+++ b/Ontology/Syyclops/Component/Capability/CapabilityCommunication.json
@@ -108,7 +108,9 @@
       "enumValues": [
         {
           "name": "API",
-          "displayName": "API",
+          "displayName": {
+            "en": "API"
+          },
           "enumValue": "API",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE1;1",
           "description": {
@@ -117,7 +119,9 @@
         },
         {
           "name": "BACnet",
-          "displayName": "BACnet",
+          "displayName": {
+            "en": "BACnet"
+          },
           "enumValue": "BACnet",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE2;1",
           "description": {
@@ -126,7 +130,9 @@
         },
         {
           "name": "Modbus",
-          "displayName": "Modbus",
+          "displayName": {
+            "en": "Modbus"
+          },
           "enumValue": "Modbus",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE3;1",
           "description": {
@@ -135,7 +141,9 @@
         },
         {
           "name": "OPCDA",
-          "displayName": "OPC DA",
+          "displayName": {
+            "en": "OPC DA"
+          },
           "enumValue": "OPC DA",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE4;1",
           "description": {
@@ -144,7 +152,9 @@
         },
         {
           "name": "OPCUA",
-          "displayName": "OPC UA",
+          "displayName": {
+            "en": "OPC UA"
+          },
           "enumValue": "OPC UA",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE5;1",
           "description": {
@@ -153,7 +163,9 @@
         },
         {
           "name": "KNX",
-          "displayName": "KNX",
+          "displayName": {
+            "en": "KNX"
+          },
           "enumValue": "KNX",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:KNX;1",
           "description": {
@@ -162,7 +174,9 @@
         },
         {
           "name": "LonWorks",
-          "displayName": "LonWorks",
+          "displayName": {
+            "en": "LonWorks"
+          },
           "enumValue": "LonWorks",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:LonWorks;1",
           "description": {
@@ -171,7 +185,9 @@
         },
         {
           "name": "DALI",
-          "displayName": "DALI",
+          "displayName": {
+            "en": "DALI"
+          },
           "enumValue": "DALI",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:DALI;1",
           "description": {
@@ -180,7 +196,9 @@
         },
         {
           "name": "MBus",
-          "displayName": "M-Bus",
+          "displayName": {
+            "en": "M-Bus"
+          },
           "enumValue": "M-Bus",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:MBus;1",
           "description": {
@@ -189,7 +207,9 @@
         },
         {
           "name": "SNMP",
-          "displayName": "SNMP",
+          "displayName": {
+            "en": "SNMP"
+          },
           "enumValue": "SNMP",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SNMP;1",
           "description": {
@@ -198,7 +218,9 @@
         },
         {
           "name": "MQTT",
-          "displayName": "MQTT",
+          "displayName": {
+            "en": "MQTT"
+          },
           "enumValue": "MQTT",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:MQTT;1",
           "description": {
@@ -207,7 +229,9 @@
         },
         {
           "name": "IoTHub",
-          "displayName": "IoT Hub",
+          "displayName": {
+            "en": "IoT Hub"
+          },
           "enumValue": "IoT Hub",
           "@id": "dtmi:com:syyclops:CapabilityCommunication:SE6;1",
           "description": {
@@ -258,79 +282,105 @@
             "enumValues": [
               {
                 "name": "Accumulator",
-                "displayName": "Accumulator",
+                "displayName": {
+                  "en": "Accumulator"
+                },
                 "enumValue": "ACC",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Accumulator;1"
               },
               {
                 "name": "Analog_Input",
-                "displayName": "Analog Input",
+                "displayName": {
+                  "en": "Analog Input"
+                },
                 "enumValue": "AI",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Analog_Input;1"
               },
               {
                 "name": "Analog_Output",
-                "displayName": "Analog Output",
+                "displayName": {
+                  "en": "Analog Output"
+                },
                 "enumValue": "AO",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Analog_Output;1"
               },
               {
                 "name": "Analog_Value",
-                "displayName": "Analog Value",
+                "displayName": {
+                  "en": "Analog Value"
+                },
                 "enumValue": "AV",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Analog_Value;1"
               },
               {
                 "name": "Binary_Input",
-                "displayName": "Binary Input",
+                "displayName": {
+                  "en": "Binary Input"
+                },
                 "enumValue": "BI",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Binary_Input;1"
               },
               {
                 "name": "Binary_Output",
-                "displayName": "Binary Output",
+                "displayName": {
+                  "en": "Binary Output"
+                },
                 "enumValue": "BO",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Binary_Output;1"
               },
               {
                 "name": "Binary_Value",
-                "displayName": "Binary Value",
+                "displayName": {
+                  "en": "Binary Value"
+                },
                 "enumValue": "BV",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Binary_Value;1"
               },
               {
                 "name": "Calendar",
-                "displayName": "Calendar",
+                "displayName": {
+                  "en": "Calendar"
+                },
                 "enumValue": "CAL",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Calendar;1"
               },
               {
                 "name": "Device",
-                "displayName": "Device",
+                "displayName": {
+                  "en": "Device"
+                },
                 "enumValue": "DEV",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Device;1"
               },
               {
                 "name": "MultiState_Input",
-                "displayName": "Multi-State Input",
+                "displayName": {
+                  "en": "Multi-State Input"
+                },
                 "enumValue": "MSI",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:MultiState_Input;1"
               },
               {
                 "name": "MultiState_Output",
-                "displayName": "Multi-State Output",
+                "displayName": {
+                  "en": "Multi-State Output"
+                },
                 "enumValue": "MSO",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:MultiState_Output;1"
               },
               {
                 "name": "MultiState_Value",
-                "displayName": "Multi-State Value",
+                "displayName": {
+                  "en": "Multi-State Value"
+                },
                 "enumValue": "MSV",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:MultiState_Value;1"
               },
               {
                 "name": "Schedule",
-                "displayName": "Schedule",
+                "displayName": {
+                  "en": "Schedule"
+                },
                 "enumValue": "SCHED",
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:Schedule;1"
               }
@@ -368,67 +418,89 @@
             "enumValues": [
               {
                 "name": "bit_1",
-                "displayName": "1-bit Binary",
+                "displayName": {
+                  "en": "1-bit Binary"
+                },
                 "enumValue": 0,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:bit_1;1"
               },
               {
                 "name": "uint_8",
-                "displayName": "8-bit Unsigned Integer",
+                "displayName": {
+                  "en": "8-bit Unsigned Integer"
+                },
                 "enumValue": 1,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:uint_8;1"
               },
               {
                 "name": "int_8",
-                "displayName": "8-bit Signed Integer",
+                "displayName": {
+                  "en": "8-bit Signed Integer"
+                },
                 "enumValue": 2,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:int_8;1"
               },
               {
                 "name": "uint_16",
-                "displayName": "16-bit Unsigned Integer",
+                "displayName": {
+                  "en": "16-bit Unsigned Integer"
+                },
                 "enumValue": 3,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:uint_16;1"
               },
               {
                 "name": "int_16",
-                "displayName": "16-bit Signed Integer",
+                "displayName": {
+                  "en": "16-bit Signed Integer"
+                },
                 "enumValue": 4,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:int_16;1"
               },
               {
                 "name": "uint_32",
-                "displayName": "32-bit Unsigned Integer",
+                "displayName": {
+                  "en": "32-bit Unsigned Integer"
+                },
                 "enumValue": 5,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:uint_32;1"
               },
               {
                 "name": "int_32",
-                "displayName": "32-bit Signed Integer",
+                "displayName": {
+                  "en": "32-bit Signed Integer"
+                },
                 "enumValue": 6,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:int_32;1"
               },
               {
                 "name": "float_32",
-                "displayName": "32-bit Floating Capability",
+                "displayName": {
+                  "en": "32-bit Floating Capability"
+                },
                 "enumValue": 7,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:float_32;1"
               },
               {
                 "name": "uint_64",
-                "displayName": "64-bit Unsigned Integer",
+                "displayName": {
+                  "en": "64-bit Unsigned Integer"
+                },
                 "enumValue": 8,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:uint_64;1"
               },
               {
                 "name": "int_64",
-                "displayName": "64-bit Signed Integer",
+                "displayName": {
+                  "en": "64-bit Signed Integer"
+                },
                 "enumValue": 9,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:int_64;1"
               },
               {
                 "name": "double_64",
-                "displayName": "64-bit Double Precision Floating Capability",
+                "displayName": {
+                  "en": "64-bit Double Precision Floating Capability"
+                },
                 "enumValue": 10,
                 "@id": "dtmi:com:syyclops:CapabilityCommunication:double_64;1"
               }

--- a/Ontology/Syyclops/Component/Capability/CapabilityPropertySet.json
+++ b/Ontology/Syyclops/Component/Capability/CapabilityPropertySet.json
@@ -16,51 +16,81 @@
         "enumValues": [
           {
             "enumValue": "Cooldown",
+            "displayName": {
+              "en": "Cooldown"
+            },
             "name": "Cooldown",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Cooldown;1"
           },
           {
             "enumValue": "Cooling",
+            "displayName": {
+              "en": "Cooling"
+            },
             "name": "Cooling",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Cooling;1"
           },
           {
             "enumValue": "Depressurize",
+            "displayName": {
+              "en": "Depressurize"
+            },
             "name": "Depressurize",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Depressurize;1"
           },
           {
             "enumValue": "Economizing",
+            "displayName": {
+              "en": "Economizing"
+            },
             "name": "Economizing",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Economizing;1"
           },
           {
             "enumValue": "Heating",
+            "displayName": {
+              "en": "Heating"
+            },
             "name": "Heating",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Heating;1"
           },
           {
             "enumValue": "Manual",
+            "displayName": {
+              "en": "Manual"
+            },
             "name": "Manual",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Manual;1"
           },
           {
             "enumValue": "Pressurize",
+            "displayName": {
+              "en": "Pressurize"
+            },
             "name": "Pressurize",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Pressurize;1"
           },
           {
             "enumValue": "Purge",
+            "displayName": {
+              "en": "Purge"
+            },
             "name": "Purge",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Purge;1"
           },
           {
             "enumValue": "Reheat",
+            "displayName": {
+              "en": "Reheat"
+            },
             "name": "Reheat",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Reheat;1"
           },
           {
             "enumValue": "Warmup",
+            "displayName": {
+              "en": "Warmup"
+            },
             "name": "Warmup",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Warmup;1"
           }
@@ -98,61 +128,97 @@
         "enumValues": [
           {
             "enumValue": "Battery",
+            "displayName": {
+              "en": "Battery"
+            },
             "name": "Battery",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Battery;1"
           },
           {
             "enumValue": "Coil",
+            "displayName": {
+              "en": "Coil"
+            },
             "name": "Coil",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Coil;1"
           },
           {
             "enumValue": "Compressor",
+            "displayName": {
+              "en": "Compressor"
+            },
             "name": "Compressor",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Compressor;1"
           },
           {
             "enumValue": "Condenser",
+            "displayName": {
+              "en": "Condenser"
+            },
             "name": "Condenser",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Condenser;1"
           },
           {
             "enumValue": "Damper",
+            "displayName": {
+              "en": "Damper"
+            },
             "name": "Damper",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Damper;1"
           },
           {
             "enumValue": "Evaporator",
+            "displayName": {
+              "en": "Evaporator"
+            },
             "name": "Evaporator",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Evaporator;1"
           },
           {
             "enumValue": "Fan",
+            "displayName": {
+              "en": "Fan"
+            },
             "name": "Fan",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Fan;1"
           },
           {
             "enumValue": "Filter",
+            "displayName": {
+              "en": "Filter"
+            },
             "name": "Filter",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Filter;1"
           },
           {
             "enumValue": "Motor",
+            "displayName": {
+              "en": "Motor"
+            },
             "name": "Motor",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Motor;1"
           },
           {
             "enumValue": "VFD",
+            "displayName": {
+              "en": "VFD"
+            },
             "name": "VFD",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:VFD;1"
           },
           {
             "enumValue": "coolingCoil",
+            "displayName": {
+              "en": "Cooling Coil"
+            },
             "name": "coolingCoil",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:coolingCoil;1"
           },
           {
             "enumValue": "heatingCoil",
+            "displayName": {
+              "en": "Heating Coil"
+            },
             "name": "heatingCoil",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:heatingCoil;1"
           }
@@ -203,36 +269,57 @@
         "enumValues": [
           {
             "enumValue": "A",
+            "displayName": {
+              "en": "A"
+            },
             "name": "A",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:A;1"
           },
           {
             "enumValue": "AB",
+            "displayName": {
+              "en": "AB"
+            },
             "name": "AB",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:AB;1"
           },
           {
             "enumValue": "B",
+            "displayName": {
+              "en": "B"
+            },
             "name": "B",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:B;1"
           },
           {
             "enumValue": "BC",
+            "displayName": {
+              "en": "BC"
+            },
             "name": "BC",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:BC;1"
           },
           {
             "enumValue": "C",
+            "displayName": {
+              "en": "C"
+            },
             "name": "C",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:C;1"
           },
           {
             "enumValue": "CA",
+            "displayName": {
+              "en": "CA"
+            },
             "name": "CA",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:CA;1"
           },
           {
             "enumValue": "N",
+            "displayName": {
+              "en": "N"
+            },
             "name": "N",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:N;1"
           }
@@ -257,11 +344,17 @@
         "enumValues": [
           {
             "enumValue": "Maximum",
+            "displayName": {
+              "en": "Maximum"
+            },
             "name": "Maximum",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Maximum;1"
           },
           {
             "enumValue": "Minimum",
+            "displayName": {
+              "en": "Minimum"
+            },
             "name": "Minimum",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Minimum;1"
           }
@@ -286,16 +379,25 @@
         "enumValues": [
           {
             "enumValue": "Occupied",
+            "displayName": {
+              "en": "Occupied"
+            },
             "name": "Occupied",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Occupied;1"
           },
           {
             "enumValue": "Standby",
+            "displayName": {
+              "en": "Standby"
+            },
             "name": "Standby",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Standby;1"
           },
           {
             "enumValue": "Unoccupied",
+            "displayName": {
+              "en": "Unoccupied"
+            },
             "name": "Unoccupied",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Unoccupied;1"
           }
@@ -320,286 +422,457 @@
         "enumValues": [
           {
             "enumValue": "ACElectricity",
+            "displayName": {
+              "en": "AC Electricity"
+            },
             "name": "ACElectricity",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:ACElectricity;1"
           },
           {
             "enumValue": "Air",
+            "displayName": {
+              "en": "Air"
+            },
             "name": "Air",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Air;1"
           },
           {
             "enumValue": "BlowdownWater",
+            "displayName": {
+              "en": "Blowdown Water"
+            },
             "name": "BlowdownWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:BlowdownWater;1"
           },
           {
             "enumValue": "ChilledWater",
+            "displayName": {
+              "en": "Chilled Water"
+            },
             "name": "ChilledWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:ChilledWater;1"
           },
           {
             "enumValue": "Cloudage",
+            "displayName": {
+              "en": "Cloudage"
+            },
             "name": "Cloudage",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Cloudage;1"
           },
           {
             "enumValue": "ColdDomesticWater",
+            "displayName": {
+              "en": "Cold Domestic Water"
+            },
             "name": "ColdDomesticWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:ColdDomesticWater;1"
           },
           {
             "enumValue": "CompressedAir",
+            "displayName": {
+              "en": "Compressed Air"
+            },
             "name": "CompressedAir",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:CompressedAir;1"
           },
           {
             "enumValue": "Condensate",
+            "displayName": {
+              "en": "Condensate"
+            },
             "name": "Condensate",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Condensate;1"
           },
           {
             "enumValue": "CondenserWater",
+            "displayName": {
+              "en": "Condenser Water"
+            },
             "name": "CondenserWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:CondenserWater;1"
           },
           {
             "enumValue": "DCElectricity",
+            "displayName": {
+              "en": "DC Electricity"
+            },
             "name": "DCElectricity",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:DCElectricity;1"
           },
           {
             "enumValue": "Data",
+            "displayName": {
+              "en": "Data"
+            },
             "name": "Data",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Data;1"
           },
           {
             "enumValue": "DeionizedWater",
+            "displayName": {
+              "en": "Deionized Water"
+            },
             "name": "DeionizedWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:DeionizedWater;1"
           },
           {
             "enumValue": "DieselFuel",
+            "displayName": {
+              "en": "Diesel"
+            },
             "name": "DieselFuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:DieselFuel;1"
           },
           {
             "enumValue": "Drainage",
+            "displayName": {
+              "en": "Drainage"
+            },
             "name": "Drainage",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Drainage;1"
           },
           {
             "enumValue": "DriveElectricity",
+            "displayName": {
+              "en": "Drive Electricity"
+            },
             "name": "DriveElectricity",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:DriveElectricity;1"
           },
           {
             "enumValue": "Electricity",
+            "displayName": {
+              "en": "Electricity"
+            },
             "name": "Electricity",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Electricity;1"
           },
           {
             "enumValue": "EthernetData",
+            "displayName": {
+              "en": "Ethernet Data"
+            },
             "name": "EthernetData",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:EthernetData;1"
           },
           {
             "enumValue": "ExhaustGas",
+            "displayName": {
+              "en": "Exhaust Gas"
+            },
             "name": "ExhaustGas",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:ExhaustGas;1"
           },
           {
             "enumValue": "Fire",
+            "displayName": {
+              "en": "Fire"
+            },
             "name": "Fire",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Fire;1"
           },
           {
             "enumValue": "FreezingRainPrecipitation",
+            "displayName": {
+              "en": "Freezing Rain"
+            },
             "name": "FreezingRainPrecipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:FreezingRainPrecipitation;1"
           },
           {
             "enumValue": "FrostIce",
+            "displayName": {
+              "en": "Frost/Ice"
+            },
             "name": "FrostIce",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:FrostIce;1"
           },
           {
             "enumValue": "Fuel",
+            "displayName": {
+              "en": "Fuel"
+            },
             "name": "Fuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Fuel;1"
           },
           {
             "enumValue": "FuelOilFuel",
+            "displayName": {
+              "en": "Fuel Oil"
+            },
             "name": "FuelOilFuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:FuelOilFuel;1"
           },
           {
             "enumValue": "GasolineFuel",
+            "displayName": {
+              "en": "Gasoline"
+            },
             "name": "GasolineFuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:GasolineFuel;1"
           },
           {
             "enumValue": "HailPrecipitation",
+            "displayName": {
+              "en": "Hail"
+            },
             "name": "HailPrecipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:HailPrecipitation;1"
           },
           {
             "enumValue": "HighTemperatureHotWater",
+            "displayName": {
+              "en": "High Temperature Hot Water"
+            },
             "name": "HighTemperatureHotWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:HighTemperatureHotWater;1"
           },
           {
             "enumValue": "HotDomesticWater",
+            "displayName": {
+              "en": "Hot Domestic Water"
+            },
             "name": "HotDomesticWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:HotDomesticWater;1"
           },
           {
             "enumValue": "HotWater",
+            "displayName": {
+              "en": "Hot Water"
+            },
             "name": "HotWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:HotWater;1"
           },
           {
             "enumValue": "Ice",
+            "displayName": {
+              "en": "Ice"
+            },
             "name": "Ice",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Ice;1"
           },
           {
             "enumValue": "InfraredLight",
+            "displayName": {
+              "en": "Infrared Light"
+            },
             "name": "InfraredLight",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:InfraredLight;1"
           },
           {
             "enumValue": "IrrigationWater",
+            "displayName": {
+              "en": "Irrigation Water"
+            },
             "name": "IrrigationWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:IrrigationWater;1"
           },
           {
             "enumValue": "Light",
+            "displayName": {
+              "en": "Light"
+            },
             "name": "Light",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Light;1"
           },
           {
             "enumValue": "LiquidPropaneFuel",
+            "displayName": {
+              "en": "Liquid Propane"
+            },
             "name": "LiquidPropaneFuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:LiquidPropaneFuel;1"
           },
           {
             "enumValue": "LowTemperatureHotWater",
+            "displayName": {
+              "en": "Low Temperature Hot Water"
+            },
             "name": "LowTemperatureHotWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:LowTemperatureHotWater;1"
           },
           {
             "enumValue": "MakeupWater",
+            "displayName": {
+              "en": "Makeup Water"
+            },
             "name": "MakeupWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:MakeupWater;1"
           },
           {
             "enumValue": "MediumTemperatureHotWater",
+            "displayName": {
+              "en": "Medium Temperature Hot Water"
+            },
             "name": "MediumTemperatureHotWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:MediumTemperatureHotWater;1"
           },
           {
             "enumValue": "NaturalGasFuel",
+            "displayName": {
+              "en": "Natural Gas"
+            },
             "name": "NaturalGasFuel",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:NaturalGasFuel;1"
           },
           {
             "enumValue": "NonPotableDomesticWater",
+            "displayName": {
+              "en": "Non-Potable Domestic Water"
+            },
             "name": "NonPotableDomesticWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:NonPotableDomesticWater;1"
           },
           {
             "enumValue": "Object",
+            "displayName": {
+              "en": "Object"
+            },
             "name": "Object",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Object;1"
           },
           {
             "enumValue": "People",
+            "displayName": {
+              "en": "People"
+            },
             "name": "People",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:People;1"
           },
           {
             "enumValue": "Precipitation",
+            "displayName": {
+              "en": "Precipitation"
+            },
             "name": "Precipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Precipitation;1"
           },
           {
             "enumValue": "RainPrecipitation",
+            "displayName": {
+              "en": "Rain"
+            },
             "name": "RainPrecipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:RainPrecipitation;1"
           },
           {
             "enumValue": "Refrigerant",
+            "displayName": {
+              "en": "Refrigerant"
+            },
             "name": "Refrigerant",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Refrigerant;1"
           },
           {
             "enumValue": "SleetPrecipitation",
+            "displayName": {
+              "en": "Sleet"
+            },
             "name": "SleetPrecipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:SleetPrecipitation;1"
           },
           {
             "enumValue": "Smoke",
+            "displayName": {
+              "en": "Smoke"
+            },
             "name": "Smoke",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Smoke;1"
           },
           {
             "enumValue": "SnowPrecipitation",
+            "displayName": {
+              "en": "Snow"
+            },
             "name": "SnowPrecipitation",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:SnowPrecipitation;1"
           },
           {
             "enumValue": "Solar",
+            "displayName": {
+              "en": "Solar"
+            },
             "name": "Solar",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Solar;1"
           },
           {
             "enumValue": "Sound",
+            "displayName": {
+              "en": "Sound"
+            },
             "name": "Sound",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Sound;1"
           },
           {
             "enumValue": "SprinklerWater",
+            "displayName": {
+              "en": "Sprinkler Water"
+            },
             "name": "SprinklerWater",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:SprinklerWater;1"
           },
           {
             "enumValue": "Steam",
+            "displayName": {
+              "en": "Steam"
+            },
             "name": "Steam",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Steam;1"
           },
           {
             "enumValue": "StormDrainage",
+            "displayName": {
+              "en": "Storm Drainage"
+            },
             "name": "StormDrainage",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:StormDrainage;1"
           },
           {
             "enumValue": "UltravioletLight",
+            "displayName": {
+              "en": "Ultraviolet Light"
+            },
             "name": "UltravioletLight",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:UltravioletLight;1"
           },
           {
             "enumValue": "Urea",
+            "displayName": {
+              "en": "Urea"
+            },
             "name": "Urea",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Urea;1"
           },
           {
             "enumValue": "WasteVentDrainage",
+            "displayName": {
+              "en": "Waste Vent Drainage"
+            },
             "name": "WasteVentDrainage",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:WasteVentDrainage;1"
           },
           {
             "enumValue": "Water",
+            "displayName": {
+              "en": "Water"
+            },
             "name": "Water",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Water;1"
           },
           {
             "enumValue": "WiFiData",
+            "displayName": {
+              "en": "Wi-Fi Data"
+            },
             "name": "WiFiData",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:WiFiData;1"
           },
           {
             "enumValue": "Wind",
+            "displayName": {
+              "en": "Wind"
+            },
             "name": "Wind",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Wind;1"
           }
@@ -624,126 +897,201 @@
         "enumValues": [
           {
             "enumValue": "Azimuth",
+            "displayName": {
+              "en": "Azimuth"
+            },
             "name": "Azimuth",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Azimuth;1"
           },
           {
             "enumValue": "Bypass",
+            "displayName": {
+              "en": "Bypass"
+            },
             "name": "Bypass",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Bypass;1"
           },
           {
             "enumValue": "Circulating",
+            "displayName": {
+              "en": "Circulating"
+            },
             "name": "Circulating",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Circulating;1"
           },
           {
             "enumValue": "Delta",
+            "displayName": {
+              "en": "Delta"
+            },
             "name": "Delta",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Delta;1"
           },
           {
             "enumValue": "Discharge",
+            "displayName": {
+              "en": "Discharge"
+            },
             "name": "Discharge",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Discharge;1"
           },
           {
             "enumValue": "Download",
+            "displayName": {
+              "en": "Download"
+            },
             "name": "Download",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Download;1"
           },
           {
             "enumValue": "Economizer",
+            "displayName": {
+              "en": "Economizer"
+            },
             "name": "Economizer",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Economizer;1"
           },
           {
             "enumValue": "Entering",
+            "displayName": {
+              "en": "Entering"
+            },
             "name": "Entering",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Entering;1"
           },
           {
             "enumValue": "Exhaust",
+            "displayName": {
+              "en": "Exhaust"
+            },
             "name": "Exhaust",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Exhaust;1"
           },
           {
             "enumValue": "Export",
+            "displayName": {
+              "en": "Export"
+            },
             "name": "Export",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Export;1"
           },
           {
             "enumValue": "Header",
+            "displayName": {
+              "en": "Header"
+            },
             "name": "Header",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Header;1"
           },
           {
             "enumValue": "Import",
+            "displayName": {
+              "en": "Import"
+            },
             "name": "Import",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Import;1"
           },
           {
             "enumValue": "Input",
+            "displayName": {
+              "en": "Input"
+            },
             "name": "Input",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Input;1"
           },
           {
             "enumValue": "Inside",
+            "displayName": {
+              "en": "Inside"
+            },
             "name": "Inside",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Inside;1"
           },
           {
             "enumValue": "Leaving",
+            "displayName": {
+              "en": "Leaving"
+            },
             "name": "Leaving",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Leaving;1"
           },
           {
             "enumValue": "Mixed",
+            "displayName": {
+              "en": "Mixed"
+            },
             "name": "Mixed",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Mixed;1"
           },
           {
             "enumValue": "Net",
+            "displayName": {
+              "en": "Net"
+            },
             "name": "Net",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Net;1"
           },
           {
             "enumValue": "Output",
+            "displayName": {
+              "en": "Output"
+            },
             "name": "Output",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Output;1"
           },
           {
             "enumValue": "Outside",
+            "displayName": {
+              "en": "Outside"
+            },
             "name": "Outside",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Outside;1"
           },
           {
             "enumValue": "Return",
+            "displayName": {
+              "en": "Return"
+            },
             "name": "Return",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Return;1"
           },
           {
             "enumValue": "Supply",
+            "displayName": {
+              "en": "Supply"
+            },
             "name": "Supply",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Supply;1"
           },
           {
             "enumValue": "Underfloor",
+            "displayName": {
+              "en": "Underfloor"
+            },
             "name": "Underfloor",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Underfloor;1"
           },
           {
             "enumValue": "Upload",
+            "displayName": {
+              "en": "Upload"
+            },
             "name": "Upload",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Upload;1"
           },
           {
             "enumValue": "Zenith",
+            "displayName": {
+              "en": "Zenith"
+            },
             "name": "Zenith",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Zenith;1"
           },
           {
             "enumValue": "Zone",
+            "displayName": {
+              "en": "Zone"
+            },
             "name": "Zone",
             "@id": "dtmi:com:syyclops:CapabilityPropertySet:Zone;1"
           }

--- a/Ontology/Syyclops/Component/Currency.json
+++ b/Ontology/Syyclops/Component/Currency.json
@@ -22,553 +22,711 @@
         "enumValues": [
           {
             "name": "AED",
-            "displayName": "AED",
+            "displayName": {
+              "en": "AED"
+            },
             "description": "United Arab Emirates dirham",
             "enumValue": "AED",
             "@id": "dtmi:com:syyclops:Currency:AED;1"
           },
           {
             "name": "ARS",
-            "displayName": "ARS",
+            "displayName": {
+              "en": "ARS"
+            },
             "description": "Argentine peso",
             "enumValue": "ARS",
             "@id": "dtmi:com:syyclops:Currency:ARS;1"
           },
           {
             "name": "AUD",
-            "displayName": "AUD",
+            "displayName": {
+              "en": "AUD"
+            },
             "description": "Australian dollar",
             "enumValue": "AUD",
             "@id": "dtmi:com:syyclops:Currency:AUD;1"
           },
           {
             "name": "BOB",
-            "displayName": "BOB",
+            "displayName": {
+              "en": "BOB"
+            },
             "description": "Boliviano",
             "enumValue": "BOB",
             "@id": "dtmi:com:syyclops:Currency:BOB;1"
           },
           {
             "name": "BRL",
-            "displayName": "BRL",
+            "displayName": {
+              "en": "BRL"
+            },
             "description": "Brazilian real",
             "enumValue": "BRL",
             "@id": "dtmi:com:syyclops:Currency:BRL;1"
           },
           {
             "name": "BZD",
-            "displayName": "BZD",
+            "displayName": {
+              "en": "BZD"
+            },
             "description": "Belize dollar",
             "enumValue": "BZD",
             "@id": "dtmi:com:syyclops:Currency:BZD;1"
           },
           {
             "name": "CAD",
-            "displayName": "CAD",
+            "displayName": {
+              "en": "CAD"
+            },
             "description": "Canadian dollar",
             "enumValue": "CAD",
             "@id": "dtmi:com:syyclops:Currency:CAD;1"
           },
           {
             "name": "CHF",
-            "displayName": "CHF",
+            "displayName": {
+              "en": "CHF"
+            },
             "description": "Swiss franc",
             "enumValue": "CHF",
             "@id": "dtmi:com:syyclops:Currency:CHF;1"
           },
           {
             "name": "CLP",
-            "displayName": "CLP",
+            "displayName": {
+              "en": "CLP"
+            },
             "description": "Chilean peso",
             "enumValue": "CLP",
             "@id": "dtmi:com:syyclops:Currency:CLP;1"
           },
           {
             "name": "COP",
-            "displayName": "COP",
+            "displayName": {
+              "en": "COP"
+            },
             "description": "Colombian peso",
             "enumValue": "COP",
             "@id": "dtmi:com:syyclops:Currency:COP;1"
           },
           {
             "name": "CRC",
-            "displayName": "CRC",
+            "displayName": {
+              "en": "CRC"
+            },
             "description": "Costa Rican colon",
             "enumValue": "CRC",
             "@id": "dtmi:com:syyclops:Currency:CRC;1"
           },
           {
             "name": "CUP",
-            "displayName": "CUP",
+            "displayName": {
+              "en": "CUP"
+            },
             "description": "Cuban peso",
             "enumValue": "CUP",
             "@id": "dtmi:com:syyclops:Currency:CUP;1"
           },
           {
             "name": "CZK",
-            "displayName": "CZK",
+            "displayName": {
+              "en": "CZK"
+            },
             "description": "Czech koruna",
             "enumValue": "CZK",
             "@id": "dtmi:com:syyclops:Currency:CZK;1"
           },
           {
             "name": "DKK",
-            "displayName": "DKK",
+            "displayName": {
+              "en": "DKK"
+            },
             "description": "Danish krone",
             "enumValue": "DKK",
             "@id": "dtmi:com:syyclops:Currency:DKK;1"
           },
           {
             "name": "DOP",
-            "displayName": "DOP",
+            "displayName": {
+              "en": "DOP"
+            },
             "description": "Dominican peso",
             "enumValue": "DOP",
             "@id": "dtmi:com:syyclops:Currency:DOP;1"
           },
           {
             "name": "DZD",
-            "displayName": "DZD",
+            "displayName": {
+              "en": "DZD"
+            },
             "description": "Algerian dinar",
             "enumValue": "DZD",
             "@id": "dtmi:com:syyclops:Currency:DZD;1"
           },
           {
             "name": "EGP",
-            "displayName": "EGP",
+            "displayName": {
+              "en": "EGP"
+            },
             "description": "Egyptian pound",
             "enumValue": "EGP",
             "@id": "dtmi:com:syyclops:Currency:EGP;1"
           },
           {
             "name": "EUR",
-            "displayName": "EUR",
+            "displayName": {
+              "en": "EUR"
+            },
             "description": "Euro",
             "enumValue": "EUR",
             "@id": "dtmi:com:syyclops:Currency:EUR;1"
           },
           {
             "name": "GBP",
-            "displayName": "GBP",
+            "displayName": {
+              "en": "GBP"
+            },
             "description": "Pound sterling",
             "enumValue": "GBP",
             "@id": "dtmi:com:syyclops:Currency:GBP;1"
           },
           {
             "name": "GTQ",
-            "displayName": "GTQ",
+            "displayName": {
+              "en": "GTQ"
+            },
             "description": "Guatemalan quetzal",
             "enumValue": "GTQ",
             "@id": "dtmi:com:syyclops:Currency:GTQ;1"
           },
           {
             "name": "HKD",
-            "displayName": "HKD",
+            "displayName": {
+              "en": "HKD"
+            },
             "description": "Hong Kong dollar",
             "enumValue": "HKD",
             "@id": "dtmi:com:syyclops:Currency:HKD;1"
           },
           {
             "name": "HNL",
-            "displayName": "HNL",
+            "displayName": {
+              "en": "HNL"
+            },
             "description": "Honduran lempira",
             "enumValue": "HNL",
             "@id": "dtmi:com:syyclops:Currency:HNL;1"
           },
           {
             "name": "HRK",
-            "displayName": "HRK",
+            "displayName": {
+              "en": "HRK"
+            },
             "description": "Croatian kuna",
             "enumValue": "HRK",
             "@id": "dtmi:com:syyclops:Currency:HRK;1"
           },
           {
             "name": "HUF",
-            "displayName": "HUF",
+            "displayName": {
+              "en": "HUF"
+            },
             "description": "Hungarian forint",
             "enumValue": "HUF",
             "@id": "dtmi:com:syyclops:Currency:HUF;1"
           },
           {
             "name": "IDR",
-            "displayName": "IDR",
+            "displayName": {
+              "en": "IDR"
+            },
             "description": "Indonesian rupiah",
             "enumValue": "IDR",
             "@id": "dtmi:com:syyclops:Currency:IDR;1"
           },
           {
             "name": "ILS",
-            "displayName": "ILS",
+            "displayName": {
+              "en": "ILS"
+            },
             "description": "Israeli new shekel",
             "enumValue": "ILS",
             "@id": "dtmi:com:syyclops:Currency:ILS;1"
           },
           {
             "name": "INR",
-            "displayName": "INR",
+            "displayName": {
+              "en": "INR"
+            },
             "description": "Indian rupee",
             "enumValue": "INR",
             "@id": "dtmi:com:syyclops:Currency:INR;1"
           },
           {
             "name": "IQD",
-            "displayName": "IQD",
+            "displayName": {
+              "en": "IQD"
+            },
             "description": "Iraqi dinar",
             "enumValue": "IQD",
             "@id": "dtmi:com:syyclops:Currency:IQD;1"
           },
           {
             "name": "IRR",
-            "displayName": "IRR",
+            "displayName": {
+              "en": "IRR"
+            },
             "description": "Iranian rial",
             "enumValue": "IRR",
             "@id": "dtmi:com:syyclops:Currency:IRR;1"
           },
           {
             "name": "ISK",
-            "displayName": "ISK",
+            "displayName": {
+              "en": "ISK"
+            },
             "description": "Icelandic króna (plural: krónur)",
             "enumValue": "ISK",
             "@id": "dtmi:com:syyclops:Currency:ISK;1"
           },
           {
             "name": "JPY",
-            "displayName": "JPY",
+            "displayName": {
+              "en": "JPY"
+            },
             "description": "Japanese yen",
             "enumValue": "JPY",
             "@id": "dtmi:com:syyclops:Currency:JPY;1"
           },
           {
             "name": "KES",
-            "displayName": "KES",
+            "displayName": {
+              "en": "KES"
+            },
             "description": "Kenyan shilling",
             "enumValue": "KES",
             "@id": "dtmi:com:syyclops:Currency:KES;1"
           },
           {
             "name": "KHR",
-            "displayName": "KHR",
+            "displayName": {
+              "en": "KHR"
+            },
             "description": "Cambodian riel",
             "enumValue": "KHR",
             "@id": "dtmi:com:syyclops:Currency:KHR;1"
           },
           {
             "name": "KRW",
-            "displayName": "KRW",
+            "displayName": {
+              "en": "KRW"
+            },
             "description": "South Korean won",
             "enumValue": "KRW",
             "@id": "dtmi:com:syyclops:Currency:KRW;1"
           },
           {
             "name": "KWD",
-            "displayName": "KWD",
+            "displayName": {
+              "en": "KWD"
+            },
             "description": "Kuwaiti dinar",
             "enumValue": "KWD",
             "@id": "dtmi:com:syyclops:Currency:KWD;1"
           },
           {
             "name": "LBP",
-            "displayName": "LBP",
+            "displayName": {
+              "en": "LBP"
+            },
             "description": "Lebanese pound",
             "enumValue": "LBP",
             "@id": "dtmi:com:syyclops:Currency:LBP;1"
           },
           {
             "name": "LKR",
-            "displayName": "LKR",
+            "displayName": {
+              "en": "LKR"
+            },
             "description": "Sri Lankan rupee",
             "enumValue": "LKR",
             "@id": "dtmi:com:syyclops:Currency:LKR;1"
           },
           {
             "name": "LRD",
-            "displayName": "LRD",
+            "displayName": {
+              "en": "LRD"
+            },
             "description": "Liberian dollar",
             "enumValue": "LRD",
             "@id": "dtmi:com:syyclops:Currency:LRD;1"
           },
           {
             "name": "LYD",
-            "displayName": "LYD",
+            "displayName": {
+              "en": "LYD"
+            },
             "description": "Libyan dinar",
             "enumValue": "LYD",
             "@id": "dtmi:com:syyclops:Currency:LYD;1"
           },
           {
             "name": "MAD",
-            "displayName": "MAD",
+            "displayName": {
+              "en": "MAD"
+            },
             "description": "Moroccan dirham",
             "enumValue": "MAD",
             "@id": "dtmi:com:syyclops:Currency:MAD;1"
           },
           {
             "name": "MMK",
-            "displayName": "MMK",
+            "displayName": {
+              "en": "MMK"
+            },
             "description": "Myanmar kyat",
             "enumValue": "MMK",
             "@id": "dtmi:com:syyclops:Currency:MMK;1"
           },
           {
             "name": "MNT",
-            "displayName": "MNT",
+            "displayName": {
+              "en": "MNT"
+            },
             "description": "Mongolian tögrög",
             "enumValue": "MNT",
             "@id": "dtmi:com:syyclops:Currency:MNT;1"
           },
           {
             "name": "MXN",
-            "displayName": "MXN",
+            "displayName": {
+              "en": "MXN"
+            },
             "description": "Mexican peso",
             "enumValue": "MXN",
             "@id": "dtmi:com:syyclops:Currency:MXN;1"
           },
           {
             "name": "MYR",
-            "displayName": "MYR",
+            "displayName": {
+              "en": "MYR"
+            },
             "description": "Malaysian ringgit",
             "enumValue": "MYR",
             "@id": "dtmi:com:syyclops:Currency:MYR;1"
           },
           {
             "name": "NGN",
-            "displayName": "NGN",
+            "displayName": {
+              "en": "NGN"
+            },
             "description": "Nigerian naira",
             "enumValue": "NGN",
             "@id": "dtmi:com:syyclops:Currency:NGN;1"
           },
           {
             "name": "NIO",
-            "displayName": "NIO",
+            "displayName": {
+              "en": "NIO"
+            },
             "description": "Nicaraguan córdoba",
             "enumValue": "NIO",
             "@id": "dtmi:com:syyclops:Currency:NIO;1"
           },
           {
             "name": "NOK",
-            "displayName": "NOK",
+            "displayName": {
+              "en": "NOK"
+            },
             "description": "Norwegian krone",
             "enumValue": "NOK",
             "@id": "dtmi:com:syyclops:Currency:NOK;1"
           },
           {
             "name": "NPR",
-            "displayName": "NPR",
+            "displayName": {
+              "en": "NPR"
+            },
             "description": "Nepalese rupee",
             "enumValue": "NPR",
             "@id": "dtmi:com:syyclops:Currency:NPR;1"
           },
           {
             "name": "NZD",
-            "displayName": "NZD",
+            "displayName": {
+              "en": "NZD"
+            },
             "description": "New Zealand dollar",
             "enumValue": "NZD",
             "@id": "dtmi:com:syyclops:Currency:NZD;1"
           },
           {
             "name": "OMR",
-            "displayName": "OMR",
+            "displayName": {
+              "en": "OMR"
+            },
             "description": "Omani rial",
             "enumValue": "OMR",
             "@id": "dtmi:com:syyclops:Currency:OMR;1"
           },
           {
             "name": "PAB",
-            "displayName": "PAB",
+            "displayName": {
+              "en": "PAB"
+            },
             "description": "Panamanian balboa",
             "enumValue": "PAB",
             "@id": "dtmi:com:syyclops:Currency:PAB;1"
           },
           {
             "name": "PEN",
-            "displayName": "PEN",
+            "displayName": {
+              "en": "PEN"
+            },
             "description": "Peruvian sol",
             "enumValue": "PEN",
             "@id": "dtmi:com:syyclops:Currency:PEN;1"
           },
           {
             "name": "PGK",
-            "displayName": "PGK",
+            "displayName": {
+              "en": "PGK"
+            },
             "description": "Papua New Guinean kina",
             "enumValue": "PGK",
             "@id": "dtmi:com:syyclops:Currency:PGK;1"
           },
           {
             "name": "PHP",
-            "displayName": "PHP",
+            "displayName": {
+              "en": "PHP"
+            },
             "description": "Philippine peso",
             "enumValue": "PHP",
             "@id": "dtmi:com:syyclops:Currency:PHP;1"
           },
           {
             "name": "PKR",
-            "displayName": "PKR",
+            "displayName": {
+              "en": "PKR"
+            },
             "description": "Pakistani rupee",
             "enumValue": "PKR",
             "@id": "dtmi:com:syyclops:Currency:PKR;1"
           },
           {
             "name": "PLN",
-            "displayName": "PLN",
+            "displayName": {
+              "en": "PLN"
+            },
             "description": "Polish złoty",
             "enumValue": "PLN",
             "@id": "dtmi:com:syyclops:Currency:PLN;1"
           },
           {
             "name": "PYG",
-            "displayName": "PYG",
+            "displayName": {
+              "en": "PYG"
+            },
             "description": "Paraguayan guaraní",
             "enumValue": "PYG",
             "@id": "dtmi:com:syyclops:Currency:PYG;1"
           },
           {
             "name": "QAR",
-            "displayName": "QAR",
+            "displayName": {
+              "en": "QAR"
+            },
             "description": "Qatari riyal",
             "enumValue": "QAR",
             "@id": "dtmi:com:syyclops:Currency:QAR;1"
           },
           {
             "name": "RON",
-            "displayName": "RON",
+            "displayName": {
+              "en": "RON"
+            },
             "description": "Romanian leu",
             "enumValue": "RON",
             "@id": "dtmi:com:syyclops:Currency:RON;1"
           },
           {
             "name": "RSD",
-            "displayName": "RSD",
+            "displayName": {
+              "en": "RSD"
+            },
             "description": "Serbian dinar",
             "enumValue": "RSD",
             "@id": "dtmi:com:syyclops:Currency:RSD;1"
           },
           {
             "name": "CNY",
-            "displayName": "CNY",
+            "displayName": {
+              "en": "CNY"
+            },
             "description": "Renminbi",
             "enumValue": "CNY",
             "@id": "dtmi:com:syyclops:Currency:CNY;1"
           },
           {
             "name": "RUB",
-            "displayName": "RUB",
+            "displayName": {
+              "en": "RUB"
+            },
             "description": "Russian ruble",
             "enumValue": "RUB",
             "@id": "dtmi:com:syyclops:Currency:RUB;1"
           },
           {
             "name": "SAR",
-            "displayName": "SAR",
+            "displayName": {
+              "en": "SAR"
+            },
             "description": "Saudi riyal",
             "enumValue": "SAR",
             "@id": "dtmi:com:syyclops:Currency:SAR;1"
           },
           {
             "name": "SEK",
-            "displayName": "SEK",
+            "displayName": {
+              "en": "SEK"
+            },
             "description": "Swedish krona (plural: kronor)",
             "enumValue": "SEK",
             "@id": "dtmi:com:syyclops:Currency:SEK;1"
           },
           {
             "name": "SGD",
-            "displayName": "SGD",
+            "displayName": {
+              "en": "SGD"
+            },
             "description": "Singapore dollar",
             "enumValue": "SGD",
             "@id": "dtmi:com:syyclops:Currency:SGD;1"
           },
           {
             "name": "SVC",
-            "displayName": "SVC",
+            "displayName": {
+              "en": "SVC"
+            },
             "description": "Salvadoran colón",
             "enumValue": "SVC",
             "@id": "dtmi:com:syyclops:Currency:SVC;1"
           },
           {
             "name": "SYP",
-            "displayName": "SYP",
+            "displayName": {
+              "en": "SYP"
+            },
             "description": "Syrian pound",
             "enumValue": "SYP",
             "@id": "dtmi:com:syyclops:Currency:SYP;1"
           },
           {
             "name": "THB",
-            "displayName": "THB",
+            "displayName": {
+              "en": "THB"
+            },
             "description": "Thai baht",
             "enumValue": "THB",
             "@id": "dtmi:com:syyclops:Currency:THB;1"
           },
           {
             "name": "TND",
-            "displayName": "TND",
+            "displayName": {
+              "en": "TND"
+            },
             "description": "Tunisian dinar",
             "enumValue": "TND",
             "@id": "dtmi:com:syyclops:Currency:TND;1"
           },
           {
             "name": "TRY",
-            "displayName": "TRY",
+            "displayName": {
+              "en": "TRY"
+            },
             "description": "Turkish lira",
             "enumValue": "TRY",
             "@id": "dtmi:com:syyclops:Currency:TRY;1"
           },
           {
             "name": "TWD",
-            "displayName": "TWD",
+            "displayName": {
+              "en": "TWD"
+            },
             "description": "New Taiwan dollar",
             "enumValue": "TWD",
             "@id": "dtmi:com:syyclops:Currency:TWD;1"
           },
           {
             "name": "UAH",
-            "displayName": "UAH",
+            "displayName": {
+              "en": "UAH"
+            },
             "description": "Ukrainian hryvnia",
             "enumValue": "UAH",
             "@id": "dtmi:com:syyclops:Currency:UAH;1"
           },
           {
             "name": "USD",
-            "displayName": "USD",
+            "displayName": {
+              "en": "USD"
+            },
             "description": "United States dollar",
             "enumValue": "USD",
             "@id": "dtmi:com:syyclops:Currency:USD;1"
           },
           {
             "name": "UYU",
-            "displayName": "UYU",
+            "displayName": {
+              "en": "UYU"
+            },
             "description": "Uruguayan peso",
             "enumValue": "UYU",
             "@id": "dtmi:com:syyclops:Currency:UYU;1"
           },
           {
             "name": "VES",
-            "displayName": "VES",
+            "displayName": {
+              "en": "VES"
+            },
             "description": "Venezuelan bolívar soberano",
             "enumValue": "VES",
             "@id": "dtmi:com:syyclops:Currency:VES;1"
           },
           {
             "name": "VND",
-            "displayName": "VND",
+            "displayName": {
+              "en": "VND"
+            },
             "description": "Vietnamese đồng",
             "enumValue": "VND",
             "@id": "dtmi:com:syyclops:Currency:VND;1"
           },
           {
             "name": "YER",
-            "displayName": "YER",
+            "displayName": {
+              "en": "YER"
+            },
             "description": "Yemeni rial",
             "enumValue": "YER",
             "@id": "dtmi:com:syyclops:Currency:YER;1"
           },
           {
             "name": "ZAR",
-            "displayName": "ZAR",
+            "displayName": {
+              "en": "ZAR"
+            },
             "description": "South African rand",
             "enumValue": "ZAR",
             "@id": "dtmi:com:syyclops:Currency:ZAR;1"
           },
           {
             "name": "ZWL",
-            "displayName": "ZWL",
+            "displayName": {
+              "en": "ZWL"
+            },
             "description": "Zimbabwean dollar",
             "enumValue": "ZWL",
             "@id": "dtmi:com:syyclops:Currency:ZWL;1"

--- a/Ontology/Syyclops/Component/TimeZone.json
+++ b/Ontology/Syyclops/Component/TimeZone.json
@@ -22,693 +22,891 @@
         "enumValues": [
           {
             "name": "AfricaCairo",
-            "displayName": "Africa/Cairo",
+            "displayName": {
+              "en": "Africa/Cairo"
+            },
             "description": "",
             "enumValue": "Africa/Cairo",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaCairo;1"
           },
           {
             "name": "AfricaCasablanca",
-            "displayName": "Africa/Casablanca",
+            "displayName": {
+              "en": "Africa/Casablanca"
+            },
             "description": "",
             "enumValue": "Africa/Casablanca",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaCasablanca;1"
           },
           {
             "name": "AfricaJohannesburg",
-            "displayName": "Africa/Johannesburg",
+            "displayName": {
+              "en": "Africa/Johannesburg"
+            },
             "description": "",
             "enumValue": "Africa/Johannesburg",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaJohannesburg;1"
           },
           {
             "name": "AfricaLagos",
-            "displayName": "Africa/Lagos",
+            "displayName": {
+              "en": "Africa/Lagos"
+            },
             "description": "West Africa Time",
             "enumValue": "Africa/Lagos",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaLagos;1"
           },
           {
             "name": "AfricaMaputo",
-            "displayName": "Africa/Maputo",
+            "displayName": {
+              "en": "Africa/Maputo"
+            },
             "description": "Central Africa Time",
             "enumValue": "Africa/Maputo",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaMaputo;1"
           },
           {
             "name": "AfricaNairobi",
-            "displayName": "Africa/Nairobi",
+            "displayName": {
+              "en": "Africa/Nairobi"
+            },
             "description": "",
             "enumValue": "Africa/Nairobi",
             "@id": "dtmi:com:syyclops:TimeZone:AfricaNairobi;1"
           },
           {
             "name": "AmericaAnchorage",
-            "displayName": "America/Anchorage",
+            "displayName": {
+              "en": "America/Anchorage"
+            },
             "description": "Alaska (most areas)",
             "enumValue": "America/Anchorage",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaAnchorage;1"
           },
           {
             "name": "AmericaArgentinaBuenos_Aires",
-            "displayName": "America/Argentina/Buenos_Aires",
+            "displayName": {
+              "en": "America/Argentina/Buenos_Aires"
+            },
             "description": "Buenos Aires (BA, CF)",
             "enumValue": "America/Argentina/Buenos_Aires",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaArgentinaBuenos_Aires;1"
           },
           {
             "name": "AmericaBogota",
-            "displayName": "America/Bogota",
+            "displayName": {
+              "en": "America/Bogota"
+            },
             "description": "",
             "enumValue": "America/Bogota",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaBogota;1"
           },
           {
             "name": "AmericaCaracas",
-            "displayName": "America/Caracas",
+            "displayName": {
+              "en": "America/Caracas"
+            },
             "description": "",
             "enumValue": "America/Caracas",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaCaracas;1"
           },
           {
             "name": "AmericaChicago",
-            "displayName": "America/Chicago",
+            "displayName": {
+              "en": "America/Chicago"
+            },
             "description": "Central (most areas)",
             "enumValue": "America/Chicago",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaChicago;1"
           },
           {
             "name": "AmericaCosta_Rica",
-            "displayName": "America/Costa_Rica",
+            "displayName": {
+              "en": "America/Costa_Rica"
+            },
             "description": "",
             "enumValue": "America/Costa_Rica",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaCosta_Rica;1"
           },
           {
             "name": "AmericaDenver",
-            "displayName": "America/Denver",
+            "displayName": {
+              "en": "America/Denver"
+            },
             "description": "Mountain (most areas)",
             "enumValue": "America/Denver",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaDenver;1"
           },
           {
             "name": "AmericaEdmonton",
-            "displayName": "America/Edmonton",
+            "displayName": {
+              "en": "America/Edmonton"
+            },
             "description": "Mountain - AB; BC (E); SK (W)",
             "enumValue": "America/Edmonton",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaEdmonton;1"
           },
           {
             "name": "AmericaHalifax",
-            "displayName": "America/Halifax",
+            "displayName": {
+              "en": "America/Halifax"
+            },
             "description": "Atlantic - NS (most areas); PE",
             "enumValue": "America/Halifax",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaHalifax;1"
           },
           {
             "name": "AmericaIndianaIndianapolis",
-            "displayName": "America/Indiana/Indianapolis",
+            "displayName": {
+              "en": "America/Indiana/Indianapolis"
+            },
             "description": "Eastern - IN (most areas)",
             "enumValue": "America/Indiana/Indianapolis",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaIndianaIndianapolis;1"
           },
           {
             "name": "AmericaLima",
-            "displayName": "America/Lima",
+            "displayName": {
+              "en": "America/Lima"
+            },
             "description": "",
             "enumValue": "America/Lima",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaLima;1"
           },
           {
             "name": "AmericaLos_Angeles",
-            "displayName": "America/Los_Angeles",
+            "displayName": {
+              "en": "America/Los_Angeles"
+            },
             "description": "Pacific",
             "enumValue": "America/Los_Angeles",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaLos_Angeles;1"
           },
           {
             "name": "AmericaMexico_City",
-            "displayName": "America/Mexico_City",
+            "displayName": {
+              "en": "America/Mexico_City"
+            },
             "description": "Central Time",
             "enumValue": "America/Mexico_City",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaMexico_City;1"
           },
           {
             "name": "AmericaNew_York",
-            "displayName": "America/New_York",
+            "displayName": {
+              "en": "America/New_York"
+            },
             "description": "Eastern (most areas)",
             "enumValue": "America/New_York",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaNew_York;1"
           },
           {
             "name": "AmericaPhoenix",
-            "displayName": "America/Phoenix",
+            "displayName": {
+              "en": "America/Phoenix"
+            },
             "description": "MST - Arizona (except Navajo), Creston BC",
             "enumValue": "America/Phoenix",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaPhoenix;1"
           },
           {
             "name": "AmericaSantiago",
-            "displayName": "America/Santiago",
+            "displayName": {
+              "en": "America/Santiago"
+            },
             "description": "Chile (most areas)",
             "enumValue": "America/Santiago",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaSantiago;1"
           },
           {
             "name": "AmericaSao_Paulo",
-            "displayName": "America/Sao_Paulo",
+            "displayName": {
+              "en": "America/Sao_Paulo"
+            },
             "description": "Brazil (southeast: GO, DF, MG, ES, RJ, SP, PR, SC, RS)",
             "enumValue": "America/Sao_Paulo",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaSao_Paulo;1"
           },
           {
             "name": "AmericaWhitehorse",
-            "displayName": "America/Whitehorse",
+            "displayName": {
+              "en": "America/Whitehorse"
+            },
             "description": "MST - Yukon (east)",
             "enumValue": "America/Whitehorse",
             "@id": "dtmi:com:syyclops:TimeZone:AmericaWhitehorse;1"
           },
           {
             "name": "AsiaBaghdad",
-            "displayName": "Asia/Baghdad",
+            "displayName": {
+              "en": "Asia/Baghdad"
+            },
             "description": "",
             "enumValue": "Asia/Baghdad",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaBaghdad;1"
           },
           {
             "name": "AsiaBangkok",
-            "displayName": "Asia/Bangkok",
+            "displayName": {
+              "en": "Asia/Bangkok"
+            },
             "description": "Indochina (most areas)",
             "enumValue": "Asia/Bangkok",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaBangkok;1"
           },
           {
             "name": "AsiaDubai",
-            "displayName": "Asia/Dubai",
+            "displayName": {
+              "en": "Asia/Dubai"
+            },
             "description": "",
             "enumValue": "Asia/Dubai",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaDubai;1"
           },
           {
             "name": "AsiaHong_Kong",
-            "displayName": "Asia/Hong_Kong",
+            "displayName": {
+              "en": "Asia/Hong_Kong"
+            },
             "description": "",
             "enumValue": "Asia/Hong_Kong",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaHong_Kong;1"
           },
           {
             "name": "AsiaJakarta",
-            "displayName": "Asia/Jakarta",
+            "displayName": {
+              "en": "Asia/Jakarta"
+            },
             "description": "Java, Sumatra",
             "enumValue": "Asia/Jakarta",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaJakarta;1"
           },
           {
             "name": "AsiaKabul",
-            "displayName": "Asia/Kabul",
+            "displayName": {
+              "en": "Asia/Kabul"
+            },
             "description": "",
             "enumValue": "Asia/Kabul",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaKabul;1"
           },
           {
             "name": "AsiaKarachi",
-            "displayName": "Asia/Karachi",
+            "displayName": {
+              "en": "Asia/Karachi"
+            },
             "description": "",
             "enumValue": "Asia/Karachi",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaKarachi;1"
           },
           {
             "name": "AsiaKathmandu",
-            "displayName": "Asia/Kathmandu",
+            "displayName": {
+              "en": "Asia/Kathmandu"
+            },
             "description": "",
             "enumValue": "Asia/Kathmandu",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaKathmandu;1"
           },
           {
             "name": "AsiaKolkata",
-            "displayName": "Asia/Kolkata",
+            "displayName": {
+              "en": "Asia/Kolkata"
+            },
             "description": "",
             "enumValue": "Asia/Kolkata",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaKolkata;1"
           },
           {
             "name": "AsiaKuala_Lumpur",
-            "displayName": "Asia/Kuala_Lumpur",
+            "displayName": {
+              "en": "Asia/Kuala_Lumpur"
+            },
             "description": "Malaysia (peninsula)",
             "enumValue": "Asia/Kuala_Lumpur",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaKuala_Lumpur;1"
           },
           {
             "name": "AsiaPyongyang",
-            "displayName": "Asia/Pyongyang",
+            "displayName": {
+              "en": "Asia/Pyongyang"
+            },
             "description": "",
             "enumValue": "Asia/Pyongyang",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaPyongyang;1"
           },
           {
             "name": "AsiaRiyadh",
-            "displayName": "Asia/Riyadh",
+            "displayName": {
+              "en": "Asia/Riyadh"
+            },
             "description": "Arabia, Syowa",
             "enumValue": "Asia/Riyadh",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaRiyadh;1"
           },
           {
             "name": "AsiaSeoul",
-            "displayName": "Asia/Seoul",
+            "displayName": {
+              "en": "Asia/Seoul"
+            },
             "description": "",
             "enumValue": "Asia/Seoul",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaSeoul;1"
           },
           {
             "name": "AsiaShanghai",
-            "displayName": "Asia/Shanghai",
+            "displayName": {
+              "en": "Asia/Shanghai"
+            },
             "description": "Beijing Time",
             "enumValue": "Asia/Shanghai",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaShanghai;1"
           },
           {
             "name": "AsiaSingapore",
-            "displayName": "Asia/Singapore",
+            "displayName": {
+              "en": "Asia/Singapore"
+            },
             "description": "Singapore, peninsular Malaysia",
             "enumValue": "Asia/Singapore",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaSingapore;1"
           },
           {
             "name": "AsiaTaipei",
-            "displayName": "Asia/Taipei",
+            "displayName": {
+              "en": "Asia/Taipei"
+            },
             "description": "",
             "enumValue": "Asia/Taipei",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaTaipei;1"
           },
           {
             "name": "AsiaTokyo",
-            "displayName": "Asia/Tokyo",
+            "displayName": {
+              "en": "Asia/Tokyo"
+            },
             "description": "",
             "enumValue": "Asia/Tokyo",
             "@id": "dtmi:com:syyclops:TimeZone:AsiaTokyo;1"
           },
           {
             "name": "AtlanticReykjavik",
-            "displayName": "Atlantic/Reykjavik",
+            "displayName": {
+              "en": "Atlantic/Reykjavik"
+            },
             "description": "",
             "enumValue": "Atlantic/Reykjavik",
             "@id": "dtmi:com:syyclops:TimeZone:AtlanticReykjavik;1"
           },
           {
             "name": "AustraliaAdelaide",
-            "displayName": "Australia/Adelaide",
+            "displayName": {
+              "en": "Australia/Adelaide"
+            },
             "description": "South Australia",
             "enumValue": "Australia/Adelaide",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaAdelaide;1"
           },
           {
             "name": "AustraliaBrisbane",
-            "displayName": "Australia/Brisbane",
+            "displayName": {
+              "en": "Australia/Brisbane"
+            },
             "description": "Queensland (most areas)",
             "enumValue": "Australia/Brisbane",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaBrisbane;1"
           },
           {
             "name": "AustraliaDarwin",
-            "displayName": "Australia/Darwin",
+            "displayName": {
+              "en": "Australia/Darwin"
+            },
             "description": "Northern Territory",
             "enumValue": "Australia/Darwin",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaDarwin;1"
           },
           {
             "name": "AustraliaHobart",
-            "displayName": "Australia/Hobart",
+            "displayName": {
+              "en": "Australia/Hobart"
+            },
             "description": "Tasmania",
             "enumValue": "Australia/Hobart",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaHobart;1"
           },
           {
             "name": "AustraliaMelbourne",
-            "displayName": "Australia/Melbourne",
+            "displayName": {
+              "en": "Australia/Melbourne"
+            },
             "description": "Victoria",
             "enumValue": "Australia/Melbourne",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaMelbourne;1"
           },
           {
             "name": "AustraliaPerth",
-            "displayName": "Australia/Perth",
+            "displayName": {
+              "en": "Australia/Perth"
+            },
             "description": "Western Australia (most areas)",
             "enumValue": "Australia/Perth",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaPerth;1"
           },
           {
             "name": "AustraliaSydney",
-            "displayName": "Australia/Sydney",
+            "displayName": {
+              "en": "Australia/Sydney"
+            },
             "description": "New South Wales (most areas)",
             "enumValue": "Australia/Sydney",
             "@id": "dtmi:com:syyclops:TimeZone:AustraliaSydney;1"
           },
           {
             "name": "EtcGMT",
-            "displayName": "Etc/GMT",
+            "displayName": {
+              "en": "Etc/GMT"
+            },
             "description": "",
             "enumValue": "Etc/GMT",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT;1"
           },
           {
             "name": "EtcGMT_1",
-            "displayName": "Etc/GMT+1",
+            "displayName": {
+              "en": "Etc/GMT+1"
+            },
             "description": "",
             "enumValue": "Etc/GMT+1",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_1;1"
           },
           {
             "name": "EtcGMT_10",
-            "displayName": "Etc/GMT+10",
+            "displayName": {
+              "en": "Etc/GMT+10"
+            },
             "description": "",
             "enumValue": "Etc/GMT+10",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_10;1"
           },
           {
             "name": "EtcGMT_11",
-            "displayName": "Etc/GMT+11",
+            "displayName": {
+              "en": "Etc/GMT+11"
+            },
             "description": "",
             "enumValue": "Etc/GMT+11",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_11;1"
           },
           {
             "name": "EtcGMT_12",
-            "displayName": "Etc/GMT+12",
+            "displayName": {
+              "en": "Etc/GMT+12"
+            },
             "description": "",
             "enumValue": "Etc/GMT+12",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_12;1"
           },
           {
             "name": "EtcGMT_2",
-            "displayName": "Etc/GMT+2",
+            "displayName": {
+              "en": "Etc/GMT+2"
+            },
             "description": "",
             "enumValue": "Etc/GMT+2",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_2;1"
           },
           {
             "name": "EtcGMT_3",
-            "displayName": "Etc/GMT+3",
+            "displayName": {
+              "en": "Etc/GMT+3"
+            },
             "description": "",
             "enumValue": "Etc/GMT+3",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_3;1"
           },
           {
             "name": "EtcGMT_4",
-            "displayName": "Etc/GMT+4",
+            "displayName": {
+              "en": "Etc/GMT+4"
+            },
             "description": "",
             "enumValue": "Etc/GMT+4",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_4;1"
           },
           {
             "name": "EtcGMT_5",
-            "displayName": "Etc/GMT+5",
+            "displayName": {
+              "en": "Etc/GMT+5"
+            },
             "description": "",
             "enumValue": "Etc/GMT+5",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_5;1"
           },
           {
             "name": "EtcGMT_6",
-            "displayName": "Etc/GMT+6",
+            "displayName": {
+              "en": "Etc/GMT+6"
+            },
             "description": "",
             "enumValue": "Etc/GMT+6",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_6;1"
           },
           {
             "name": "EtcGMT_7",
-            "displayName": "Etc/GMT+7",
+            "displayName": {
+              "en": "Etc/GMT+7"
+            },
             "description": "",
             "enumValue": "Etc/GMT+7",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_7;1"
           },
           {
             "name": "EtcGMT_8",
-            "displayName": "Etc/GMT+8",
+            "displayName": {
+              "en": "Etc/GMT+8"
+            },
             "description": "",
             "enumValue": "Etc/GMT+8",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_8;1"
           },
           {
             "name": "EtcGMT_9",
-            "displayName": "Etc/GMT+9",
+            "displayName": {
+              "en": "Etc/GMT+9"
+            },
             "description": "",
             "enumValue": "Etc/GMT+9",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT_9;1"
           },
           {
             "name": "EtcGMT1",
-            "displayName": "Etc/GMT-1",
+            "displayName": {
+              "en": "Etc/GMT-1"
+            },
             "description": "",
             "enumValue": "Etc/GMT-1",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT1;1"
           },
           {
             "name": "EtcGMT10",
-            "displayName": "Etc/GMT-10",
+            "displayName": {
+              "en": "Etc/GMT-10"
+            },
             "description": "",
             "enumValue": "Etc/GMT-10",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT10;1"
           },
           {
             "name": "EtcGMT11",
-            "displayName": "Etc/GMT-11",
+            "displayName": {
+              "en": "Etc/GMT-11"
+            },
             "description": "",
             "enumValue": "Etc/GMT-11",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT11;1"
           },
           {
             "name": "EtcGMT12",
-            "displayName": "Etc/GMT-12",
+            "displayName": {
+              "en": "Etc/GMT-12"
+            },
             "description": "",
             "enumValue": "Etc/GMT-12",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT12;1"
           },
           {
             "name": "EtcGMT13",
-            "displayName": "Etc/GMT-13",
+            "displayName": {
+              "en": "Etc/GMT-13"
+            },
             "description": "",
             "enumValue": "Etc/GMT-13",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT13;1"
           },
           {
             "name": "EtcGMT14",
-            "displayName": "Etc/GMT-14",
+            "displayName": {
+              "en": "Etc/GMT-14"
+            },
             "description": "",
             "enumValue": "Etc/GMT-14",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT14;1"
           },
           {
             "name": "EtcGMT2",
-            "displayName": "Etc/GMT-2",
+            "displayName": {
+              "en": "Etc/GMT-2"
+            },
             "description": "",
             "enumValue": "Etc/GMT-2",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT2;1"
           },
           {
             "name": "EtcGMT3",
-            "displayName": "Etc/GMT-3",
+            "displayName": {
+              "en": "Etc/GMT-3"
+            },
             "description": "",
             "enumValue": "Etc/GMT-3",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT3;1"
           },
           {
             "name": "EtcGMT4",
-            "displayName": "Etc/GMT-4",
+            "displayName": {
+              "en": "Etc/GMT-4"
+            },
             "description": "",
             "enumValue": "Etc/GMT-4",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT4;1"
           },
           {
             "name": "EtcGMT5",
-            "displayName": "Etc/GMT-5",
+            "displayName": {
+              "en": "Etc/GMT-5"
+            },
             "description": "",
             "enumValue": "Etc/GMT-5",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT5;1"
           },
           {
             "name": "EtcGMT6",
-            "displayName": "Etc/GMT-6",
+            "displayName": {
+              "en": "Etc/GMT-6"
+            },
             "description": "",
             "enumValue": "Etc/GMT-6",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT6;1"
           },
           {
             "name": "EtcGMT7",
-            "displayName": "Etc/GMT-7",
+            "displayName": {
+              "en": "Etc/GMT-7"
+            },
             "description": "",
             "enumValue": "Etc/GMT-7",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT7;1"
           },
           {
             "name": "EtcGMT8",
-            "displayName": "Etc/GMT-8",
+            "displayName": {
+              "en": "Etc/GMT-8"
+            },
             "description": "",
             "enumValue": "Etc/GMT-8",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT8;1"
           },
           {
             "name": "EtcGMT9",
-            "displayName": "Etc/GMT-9",
+            "displayName": {
+              "en": "Etc/GMT-9"
+            },
             "description": "",
             "enumValue": "Etc/GMT-9",
             "@id": "dtmi:com:syyclops:TimeZone:EtcGMT9;1"
           },
           {
             "name": "EtcUTC",
-            "displayName": "Etc/UTC",
+            "displayName": {
+              "en": "Etc/UTC"
+            },
             "description": "",
             "enumValue": "Etc/UTC",
             "@id": "dtmi:com:syyclops:TimeZone:EtcUTC;1"
           },
           {
             "name": "EuropeAmsterdam",
-            "displayName": "Europe/Amsterdam",
+            "displayName": {
+              "en": "Europe/Amsterdam"
+            },
             "description": "",
             "enumValue": "Europe/Amsterdam",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeAmsterdam;1"
           },
           {
             "name": "EuropeAthens",
-            "displayName": "Europe/Athens",
+            "displayName": {
+              "en": "Europe/Athens"
+            },
             "description": "",
             "enumValue": "Europe/Athens",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeAthens;1"
           },
           {
             "name": "EuropeBerlin",
-            "displayName": "Europe/Berlin",
+            "displayName": {
+              "en": "Europe/Berlin"
+            },
             "description": "Germany (most areas)",
             "enumValue": "Europe/Berlin",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeBerlin;1"
           },
           {
             "name": "EuropeBrussels",
-            "displayName": "Europe/Brussels",
+            "displayName": {
+              "en": "Europe/Brussels"
+            },
             "description": "",
             "enumValue": "Europe/Brussels",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeBrussels;1"
           },
           {
             "name": "EuropeBudapest",
-            "displayName": "Europe/Budapest",
+            "displayName": {
+              "en": "Europe/Budapest"
+            },
             "description": "",
             "enumValue": "Europe/Budapest",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeBudapest;1"
           },
           {
             "name": "EuropeCopenhagen",
-            "displayName": "Europe/Copenhagen",
+            "displayName": {
+              "en": "Europe/Copenhagen"
+            },
             "description": "",
             "enumValue": "Europe/Copenhagen",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeCopenhagen;1"
           },
           {
             "name": "EuropeDublin",
-            "displayName": "Europe/Dublin",
+            "displayName": {
+              "en": "Europe/Dublin"
+            },
             "description": "",
             "enumValue": "Europe/Dublin",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeDublin;1"
           },
           {
             "name": "EuropeHelsinki",
-            "displayName": "Europe/Helsinki",
+            "displayName": {
+              "en": "Europe/Helsinki"
+            },
             "description": "",
             "enumValue": "Europe/Helsinki",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeHelsinki;1"
           },
           {
             "name": "EuropeIstanbul",
-            "displayName": "Europe/Istanbul",
+            "displayName": {
+              "en": "Europe/Istanbul"
+            },
             "description": "",
             "enumValue": "Europe/Istanbul",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeIstanbul;1"
           },
           {
             "name": "EuropeLisbon",
-            "displayName": "Europe/Lisbon",
+            "displayName": {
+              "en": "Europe/Lisbon"
+            },
             "description": "Portugal (mainland)",
             "enumValue": "Europe/Lisbon",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeLisbon;1"
           },
           {
             "name": "EuropeLondon",
-            "displayName": "Europe/London",
+            "displayName": {
+              "en": "Europe/London"
+            },
             "description": "",
             "enumValue": "Europe/London",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeLondon;1"
           },
           {
             "name": "EuropeMadrid",
-            "displayName": "Europe/Madrid",
+            "displayName": {
+              "en": "Europe/Madrid"
+            },
             "description": "Spain (mainland)",
             "enumValue": "Europe/Madrid",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeMadrid;1"
           },
           {
             "name": "EuropeMinsk",
-            "displayName": "Europe/Minsk",
+            "displayName": {
+              "en": "Europe/Minsk"
+            },
             "description": "",
             "enumValue": "Europe/Minsk",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeMinsk;1"
           },
           {
             "name": "EuropeMoscow",
-            "displayName": "Europe/Moscow",
+            "displayName": {
+              "en": "Europe/Moscow"
+            },
             "description": "MSK+00 - Moscow area",
             "enumValue": "Europe/Moscow",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeMoscow;1"
           },
           {
             "name": "EuropeParis",
-            "displayName": "Europe/Paris",
+            "displayName": {
+              "en": "Europe/Paris"
+            },
             "description": "",
             "enumValue": "Europe/Paris",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeParis;1"
           },
           {
             "name": "EuropePrague",
-            "displayName": "Europe/Prague",
+            "displayName": {
+              "en": "Europe/Prague"
+            },
             "description": "",
             "enumValue": "Europe/Prague",
             "@id": "dtmi:com:syyclops:TimeZone:EuropePrague;1"
           },
           {
             "name": "EuropeRome",
-            "displayName": "Europe/Rome",
+            "displayName": {
+              "en": "Europe/Rome"
+            },
             "description": "",
             "enumValue": "Europe/Rome",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeRome;1"
           },
           {
             "name": "EuropeStockholm",
-            "displayName": "Europe/Stockholm",
+            "displayName": {
+              "en": "Europe/Stockholm"
+            },
             "description": "",
             "enumValue": "Europe/Stockholm",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeStockholm;1"
           },
           {
             "name": "EuropeVienna",
-            "displayName": "Europe/Vienna",
+            "displayName": {
+              "en": "Europe/Vienna"
+            },
             "description": "",
             "enumValue": "Europe/Vienna",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeVienna;1"
           },
           {
             "name": "EuropeZurich",
-            "displayName": "Europe/Zurich",
+            "displayName": {
+              "en": "Europe/Zurich"
+            },
             "description": "Swiss time",
             "enumValue": "Europe/Zurich",
             "@id": "dtmi:com:syyclops:TimeZone:EuropeZurich;1"
           },
           {
             "name": "PacificAuckland",
-            "displayName": "Pacific/Auckland",
+            "displayName": {
+              "en": "Pacific/Auckland"
+            },
             "description": "New Zealand time",
             "enumValue": "Pacific/Auckland",
             "@id": "dtmi:com:syyclops:TimeZone:PacificAuckland;1"
           },
           {
             "name": "PacificHonolulu",
-            "displayName": "Pacific/Honolulu",
+            "displayName": {
+              "en": "Pacific/Honolulu"
+            },
             "description": "Hawaii",
             "enumValue": "Pacific/Honolulu",
             "@id": "dtmi:com:syyclops:TimeZone:PacificHonolulu;1"

--- a/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
+++ b/Ontology/Syyclops/Event/Calendar Event/CalendarEvent.json
@@ -97,16 +97,25 @@
         "enumValues": [
           {
             "enumValue": "low",
+            "displayName": {
+              "en": "Low"
+            },
             "name": "low",
             "@id": "dtmi:com:syyclops:CalendarEvent:low;1"
           },
           {
             "enumValue": "normal",
+            "displayName": {
+              "en": "Normal"
+            },
             "name": "normal",
             "@id": "dtmi:com:syyclops:CalendarEvent:normal;1"
           },
           {
             "enumValue": "high",
+            "displayName": {
+              "en": "High"
+            },
             "name": "high",
             "@id": "dtmi:com:syyclops:CalendarEvent:high;1"
           }
@@ -158,36 +167,57 @@
                   "enumValues": [
                     {
                       "enumValue": "daily",
+                      "displayName": {
+                        "en": "Daily"
+                      },
                       "name": "daily",
                       "@id": "dtmi:com:syyclops:CalendarEvent:daily;1"
                     },
                     {
                       "enumValue": "weekly",
+                      "displayName": {
+                        "en": "Weekly"
+                      },
                       "name": "weekly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:weekly;1"
                     },
                     {
                       "enumValue": "absoluteMonthly",
+                      "displayName": {
+                        "en": "Monthly (by Date)"
+                      },
                       "name": "absoluteMonthly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:absoluteMonthly;1"
                     },
                     {
                       "enumValue": "relativeMonthly",
+                      "displayName": {
+                        "en": "Monthly (by Weekday)"
+                      },
                       "name": "relativeMonthly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:relativeMonthly;1"
                     },
                     {
                       "enumValue": "absoluteYearly",
+                      "displayName": {
+                        "en": "Yearly (by Date)"
+                      },
                       "name": "absoluteYearly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:absoluteYearly;1"
                     },
                     {
                       "enumValue": "relativeYearly",
+                      "displayName": {
+                        "en": "Yearly (by Weekday)"
+                      },
                       "name": "relativeYearly",
                       "@id": "dtmi:com:syyclops:CalendarEvent:relativeYearly;1"
                     },
                     {
                       "enumValue": "custom",
+                      "displayName": {
+                        "en": "Custom"
+                      },
                       "name": "custom",
                       "@id": "dtmi:com:syyclops:CalendarEvent:custom;1"
                     }
@@ -267,16 +297,25 @@
                   "enumValues": [
                     {
                       "enumValue": "endDate",
+                      "displayName": {
+                        "en": "End by Date"
+                      },
                       "name": "endDate",
                       "@id": "dtmi:com:syyclops:CalendarEvent:endDate;1"
                     },
                     {
                       "enumValue": "noEnd",
+                      "displayName": {
+                        "en": "No End"
+                      },
                       "name": "noEnd",
                       "@id": "dtmi:com:syyclops:CalendarEvent:noEnd;1"
                     },
                     {
                       "enumValue": "numbered",
+                      "displayName": {
+                        "en": "End After Occurrences"
+                      },
                       "name": "numbered",
                       "@id": "dtmi:com:syyclops:CalendarEvent:numbered;1"
                     }
@@ -343,6 +382,9 @@
       "enumValues": [
         {
           "enumValue": "sunday",
+          "displayName": {
+            "en": "Sunday"
+          },
           "name": "sunday",
           "@id": "dtmi:com:syyclops:CalendarEvent:sunday;1",
           "description": {
@@ -351,6 +393,9 @@
         },
         {
           "enumValue": "monday",
+          "displayName": {
+            "en": "Monday"
+          },
           "name": "monday",
           "@id": "dtmi:com:syyclops:CalendarEvent:monday;1",
           "description": {
@@ -359,6 +404,9 @@
         },
         {
           "enumValue": "tuesday",
+          "displayName": {
+            "en": "Tuesday"
+          },
           "name": "tuesday",
           "@id": "dtmi:com:syyclops:CalendarEvent:tuesday;1",
           "description": {
@@ -367,6 +415,9 @@
         },
         {
           "enumValue": "wednesday",
+          "displayName": {
+            "en": "Wednesday"
+          },
           "name": "wednesday",
           "@id": "dtmi:com:syyclops:CalendarEvent:wednesday;1",
           "description": {
@@ -375,6 +426,9 @@
         },
         {
           "enumValue": "thursday",
+          "displayName": {
+            "en": "Thursday"
+          },
           "name": "thursday",
           "@id": "dtmi:com:syyclops:CalendarEvent:thursday;1",
           "description": {
@@ -383,6 +437,9 @@
         },
         {
           "enumValue": "friday",
+          "displayName": {
+            "en": "Friday"
+          },
           "name": "friday",
           "@id": "dtmi:com:syyclops:CalendarEvent:friday;1",
           "description": {
@@ -391,6 +448,9 @@
         },
         {
           "enumValue": "saturday",
+          "displayName": {
+            "en": "Saturday"
+          },
           "name": "saturday",
           "@id": "dtmi:com:syyclops:CalendarEvent:saturday;1",
           "description": {

--- a/Ontology/Syyclops/Space/Building/Building.json
+++ b/Ontology/Syyclops/Space/Building/Building.json
@@ -329,6 +329,9 @@
       "enumValues": [
         {
           "enumValue": "Education",
+          "displayName": {
+            "en": "Education"
+          },
           "name": "Education",
           "@id": "dtmi:com:syyclops:Building:Education;1",
           "description": {
@@ -337,6 +340,9 @@
         },
         {
           "enumValue": "Food Sales",
+          "displayName": {
+            "en": "Food Sales"
+          },
           "name": "FoodSales",
           "@id": "dtmi:com:syyclops:Building:FoodSales;1",
           "description": {
@@ -345,6 +351,9 @@
         },
         {
           "enumValue": "Food Service",
+          "displayName": {
+            "en": "Food Service"
+          },
           "name": "FoodService",
           "@id": "dtmi:com:syyclops:Building:FoodService;1",
           "description": {
@@ -353,6 +362,9 @@
         },
         {
           "enumValue": "Healthcare - Inpatient",
+          "displayName": {
+            "en": "Healthcare Inpatient"
+          },
           "name": "HealthcareInpatient",
           "@id": "dtmi:com:syyclops:Building:HealthcareInpatient;1",
           "description": {
@@ -361,6 +373,9 @@
         },
         {
           "enumValue": "Healthcare - Outpatient",
+          "displayName": {
+            "en": "Healthcare Outpatient"
+          },
           "name": "HealthcareOutpatient",
           "@id": "dtmi:com:syyclops:Building:HealthcareOutpatient;1",
           "description": {
@@ -369,6 +384,9 @@
         },
         {
           "enumValue": "Lodging",
+          "displayName": {
+            "en": "Lodging"
+          },
           "name": "Lodging",
           "@id": "dtmi:com:syyclops:Building:Lodging;1",
           "description": {
@@ -377,6 +395,9 @@
         },
         {
           "enumValue": "Mercantile - Retail other than mall",
+          "displayName": {
+            "en": "Mercantile Retail (Other Than Mall)"
+          },
           "name": "MercantileRetailOtherThanMall",
           "@id": "dtmi:com:syyclops:Building:MercantileRetailOtherThanMall;1",
           "description": {
@@ -385,6 +406,9 @@
         },
         {
           "enumValue": "Mercantile - Enclosed and strip malls",
+          "displayName": {
+            "en": "Mercantile (Enclosed Mall)"
+          },
           "name": "MercantileEnclosed",
           "@id": "dtmi:com:syyclops:Building:MercantileEnclosed;1",
           "description": {
@@ -393,6 +417,9 @@
         },
         {
           "enumValue": "Office",
+          "displayName": {
+            "en": "Office"
+          },
           "name": "Office",
           "@id": "dtmi:com:syyclops:Building:Office;1",
           "description": {
@@ -401,6 +428,9 @@
         },
         {
           "enumValue": "Public Assembly",
+          "displayName": {
+            "en": "Public Assembly"
+          },
           "name": "PublicAssembly",
           "@id": "dtmi:com:syyclops:Building:PublicAssembly;1",
           "description": {
@@ -409,6 +439,9 @@
         },
         {
           "enumValue": "Public Order and Safety",
+          "displayName": {
+            "en": "Public Order and Safety"
+          },
           "name": "PublicOrderAndSafety",
           "@id": "dtmi:com:syyclops:Building:PublicOrderAndSafety;1",
           "description": {
@@ -417,6 +450,9 @@
         },
         {
           "enumValue": "Religious Worship",
+          "displayName": {
+            "en": "Religious Worship"
+          },
           "name": "ReligiousWorship",
           "@id": "dtmi:com:syyclops:Building:ReligiousWorship;1",
           "description": {
@@ -425,6 +461,9 @@
         },
         {
           "enumValue": "Service",
+          "displayName": {
+            "en": "Service"
+          },
           "name": "Service",
           "@id": "dtmi:com:syyclops:Building:Service;1",
           "description": {
@@ -433,6 +472,9 @@
         },
         {
           "enumValue": "Warehouse and Storage",
+          "displayName": {
+            "en": "Warehouse and Storage"
+          },
           "name": "WarehouseAndStorage",
           "@id": "dtmi:com:syyclops:Building:WarehouseAndStorage;1",
           "description": {
@@ -441,6 +483,9 @@
         },
         {
           "enumValue": "Other",
+          "displayName": {
+            "en": "Other"
+          },
           "name": "Other",
           "@id": "dtmi:com:syyclops:Building:Other;1",
           "description": {
@@ -449,6 +494,9 @@
         },
         {
           "enumValue": "Vacant",
+          "displayName": {
+            "en": "Vacant"
+          },
           "name": "Vacant",
           "@id": "dtmi:com:syyclops:Building:Vacant;1",
           "description": {
@@ -467,6 +515,9 @@
       "enumValues": [
         {
           "enumValue": "Bank Branch",
+          "displayName": {
+            "en": "Bank Branch"
+          },
           "name": "BankBranch",
           "@id": "dtmi:com:syyclops:Building:BankBranch;1",
           "description": {
@@ -475,6 +526,9 @@
         },
         {
           "enumValue": "Barracks",
+          "displayName": {
+            "en": "Barracks"
+          },
           "name": "Barracks",
           "@id": "dtmi:com:syyclops:Building:Barracks;1",
           "description": {
@@ -483,6 +537,9 @@
         },
         {
           "enumValue": "Convenience Store",
+          "displayName": {
+            "en": "Convenience Store"
+          },
           "name": "ConvenienceStore",
           "@id": "dtmi:com:syyclops:Building:ConvenienceStore;1",
           "description": {
@@ -491,6 +548,9 @@
         },
         {
           "enumValue": "Courthouse",
+          "displayName": {
+            "en": "Courthouse"
+          },
           "name": "Courthouse",
           "@id": "dtmi:com:syyclops:Building:Courthouse;1",
           "description": {
@@ -499,6 +559,9 @@
         },
         {
           "enumValue": "Data Center",
+          "displayName": {
+            "en": "Data Center"
+          },
           "name": "DataCenter",
           "@id": "dtmi:com:syyclops:Building:DataCenter;1",
           "description": {
@@ -507,6 +570,9 @@
         },
         {
           "enumValue": "Distribution Center",
+          "displayName": {
+            "en": "Distribution Center"
+          },
           "name": "DistributionCenter",
           "@id": "dtmi:com:syyclops:Building:DistributionCenter;1",
           "description": {
@@ -515,6 +581,9 @@
         },
         {
           "enumValue": "Financial Office",
+          "displayName": {
+            "en": "Financial Office"
+          },
           "name": "FinancialOffice",
           "@id": "dtmi:com:syyclops:Building:FinancialOffice;1",
           "description": {
@@ -523,6 +592,9 @@
         },
         {
           "enumValue": "Hospital (General Medical & Surgical)",
+          "displayName": {
+            "en": "Hospital"
+          },
           "name": "Hospital",
           "@id": "dtmi:com:syyclops:Building:Hospital;1",
           "description": {
@@ -531,6 +603,9 @@
         },
         {
           "enumValue": "Hotel",
+          "displayName": {
+            "en": "Hotel"
+          },
           "name": "Hotel",
           "@id": "dtmi:com:syyclops:Building:Hotel;1",
           "description": {
@@ -539,6 +614,9 @@
         },
         {
           "enumValue": "K-12 School",
+          "displayName": {
+            "en": "K-12 School"
+          },
           "name": "K12Schoold",
           "@id": "dtmi:com:syyclops:Building:K12Schoold;1",
           "description": {
@@ -547,6 +625,9 @@
         },
         {
           "enumValue": "Medical Office",
+          "displayName": {
+            "en": "Medical Office"
+          },
           "name": "MedicalOffice",
           "@id": "dtmi:com:syyclops:Building:MedicalOffice;1",
           "description": {
@@ -555,6 +636,9 @@
         },
         {
           "enumValue": "Multifamily Housing",
+          "displayName": {
+            "en": "Multifamily Housing"
+          },
           "name": "MultifamilyHousing",
           "@id": "dtmi:com:syyclops:Building:MultifamilyHousing;1",
           "description": {
@@ -563,6 +647,9 @@
         },
         {
           "enumValue": "Non-refrigerated Warehouse",
+          "displayName": {
+            "en": "Non-Refrigerated Warehouse"
+          },
           "name": "NonRefrigeratedWarehouse",
           "@id": "dtmi:com:syyclops:Building:NonRefrigeratedWarehouse;1",
           "description": {
@@ -571,6 +658,9 @@
         },
         {
           "enumValue": "Office",
+          "displayName": {
+            "en": "Office"
+          },
           "name": "Office",
           "@id": "dtmi:com:syyclops:Building:SE1;1",
           "description": {
@@ -579,6 +669,9 @@
         },
         {
           "enumValue": "Refrigerated Warehouse",
+          "displayName": {
+            "en": "Refrigerated Warehouse"
+          },
           "name": "RefrigeratedWarehouse",
           "@id": "dtmi:com:syyclops:Building:RefrigeratedWarehouse;1",
           "description": {
@@ -587,6 +680,9 @@
         },
         {
           "enumValue": "Residence Hall/Dormitory",
+          "displayName": {
+            "en": "Residence Hall/Dormitory"
+          },
           "name": "ResidenceHallDormitory",
           "@id": "dtmi:com:syyclops:Building:ResidenceHallDormitory;1",
           "description": {
@@ -595,6 +691,9 @@
         },
         {
           "enumValue": "Retail Store",
+          "displayName": {
+            "en": "Retail Store"
+          },
           "name": "RetailStore",
           "@id": "dtmi:com:syyclops:Building:RetailStore;1",
           "description": {
@@ -603,6 +702,9 @@
         },
         {
           "enumValue": "Single Family Home",
+          "displayName": {
+            "en": "Single Family Home"
+          },
           "name": "SingleFamilyHome",
           "@id": "dtmi:com:syyclops:Building:SingleFamilyHome;1",
           "description": {
@@ -611,6 +713,9 @@
         },
         {
           "enumValue": "Senior Living Community",
+          "displayName": {
+            "en": "Senior Living Community"
+          },
           "name": "SeniorLivingCommunity",
           "@id": "dtmi:com:syyclops:Building:SeniorLivingCommunity;1",
           "description": {
@@ -619,6 +724,9 @@
         },
         {
           "enumValue": "Supermarket/Grocery Store",
+          "displayName": {
+            "en": "Supermarket/Grocery Store"
+          },
           "name": "SupermarketGroceryStore",
           "@id": "dtmi:com:syyclops:Building:SupermarketGroceryStore;1",
           "description": {
@@ -627,6 +735,9 @@
         },
         {
           "enumValue": "Vehicle Dealership",
+          "displayName": {
+            "en": "Vehicle Dealership"
+          },
           "name": "VehicleDealership",
           "@id": "dtmi:com:syyclops:Building:VehicleDealership;1",
           "description": {
@@ -635,6 +746,9 @@
         },
         {
           "enumValue": "Wastewater Treatment Plant",
+          "displayName": {
+            "en": "Wastewater Treatment Plant"
+          },
           "name": "WastewaterTreatmentPlant",
           "@id": "dtmi:com:syyclops:Building:WastewaterTreatmentPlant;1",
           "description": {
@@ -643,6 +757,9 @@
         },
         {
           "enumValue": "Wholesale Club/Supercenter",
+          "displayName": {
+            "en": "Wholesale Club/Supercenter"
+          },
           "name": "WholesaleClubSupercenter",
           "@id": "dtmi:com:syyclops:Building:WholesaleClubSupercenter;1",
           "description": {
@@ -651,6 +768,9 @@
         },
         {
           "enumValue": "Worship Facility",
+          "displayName": {
+            "en": "Worship Facility"
+          },
           "name": "WorshipFacility",
           "@id": "dtmi:com:syyclops:Building:WorshipFacility;1",
           "description": {
@@ -669,7 +789,9 @@
       "enumValues": [
         {
           "name": "oneA",
-          "displayName": "1A - Very Hot Humid",
+          "displayName": {
+            "en": "1A - Very Hot Humid"
+          },
           "enumValue": "1A",
           "@id": "dtmi:com:syyclops:Building:oneA;1",
           "description": {
@@ -678,7 +800,9 @@
         },
         {
           "name": "twoA",
-          "displayName": "2A Hot Humid",
+          "displayName": {
+            "en": "2A Hot Humid"
+          },
           "enumValue": "2A",
           "@id": "dtmi:com:syyclops:Building:twoA;1",
           "description": {
@@ -687,7 +811,9 @@
         },
         {
           "name": "twoB",
-          "displayName": "2B Hot Dry",
+          "displayName": {
+            "en": "2B Hot Dry"
+          },
           "enumValue": "2B",
           "@id": "dtmi:com:syyclops:Building:twoB;1",
           "description": {
@@ -696,7 +822,9 @@
         },
         {
           "name": "threeA",
-          "displayName": "3A Warm Humid",
+          "displayName": {
+            "en": "3A Warm Humid"
+          },
           "enumValue": "3A",
           "@id": "dtmi:com:syyclops:Building:threeA;1",
           "description": {
@@ -705,7 +833,9 @@
         },
         {
           "name": "threeB",
-          "displayName": "3B Warm Dry",
+          "displayName": {
+            "en": "3B Warm Dry"
+          },
           "enumValue": "3B",
           "@id": "dtmi:com:syyclops:Building:threeB;1",
           "description": {
@@ -714,7 +844,9 @@
         },
         {
           "name": "threeC",
-          "displayName": "3C Warm Marine",
+          "displayName": {
+            "en": "3C Warm Marine"
+          },
           "enumValue": "3C",
           "@id": "dtmi:com:syyclops:Building:threeC;1",
           "description": {
@@ -723,7 +855,9 @@
         },
         {
           "name": "fourA",
-          "displayName": "4A Mixed Humid",
+          "displayName": {
+            "en": "4A Mixed Humid"
+          },
           "enumValue": "4A",
           "@id": "dtmi:com:syyclops:Building:fourA;1",
           "description": {
@@ -732,7 +866,9 @@
         },
         {
           "name": "fourB",
-          "displayName": "4B Mixed Dry",
+          "displayName": {
+            "en": "4B Mixed Dry"
+          },
           "enumValue": "4B",
           "@id": "dtmi:com:syyclops:Building:fourB;1",
           "description": {
@@ -741,7 +877,9 @@
         },
         {
           "name": "fourC",
-          "displayName": "4C Mixed Marine",
+          "displayName": {
+            "en": "4C Mixed Marine"
+          },
           "enumValue": "4C",
           "@id": "dtmi:com:syyclops:Building:fourC;1",
           "description": {
@@ -750,7 +888,9 @@
         },
         {
           "name": "fiveA",
-          "displayName": "5A Cool Humid",
+          "displayName": {
+            "en": "5A Cool Humid"
+          },
           "enumValue": "5A",
           "@id": "dtmi:com:syyclops:Building:fiveA;1",
           "description": {
@@ -759,7 +899,9 @@
         },
         {
           "name": "fiveB",
-          "displayName": "5B Cool Dry",
+          "displayName": {
+            "en": "5B Cool Dry"
+          },
           "enumValue": "5B",
           "@id": "dtmi:com:syyclops:Building:fiveB;1",
           "description": {
@@ -768,7 +910,9 @@
         },
         {
           "name": "fiveC",
-          "displayName": "5C Cool Marine",
+          "displayName": {
+            "en": "5C Cool Marine"
+          },
           "enumValue": "5C",
           "@id": "dtmi:com:syyclops:Building:fiveC;1",
           "description": {
@@ -777,7 +921,9 @@
         },
         {
           "name": "sixA",
-          "displayName": "6A Cold Humid",
+          "displayName": {
+            "en": "6A Cold Humid"
+          },
           "enumValue": "6A",
           "@id": "dtmi:com:syyclops:Building:sixA;1",
           "description": {
@@ -786,7 +932,9 @@
         },
         {
           "name": "sixB",
-          "displayName": "6B Cold Dry",
+          "displayName": {
+            "en": "6B Cold Dry"
+          },
           "enumValue": "6B",
           "@id": "dtmi:com:syyclops:Building:sixB;1",
           "description": {
@@ -795,7 +943,9 @@
         },
         {
           "name": "seven",
-          "displayName": "7 Very Cold",
+          "displayName": {
+            "en": "7 Very Cold"
+          },
           "enumValue": "7",
           "@id": "dtmi:com:syyclops:Building:seven;1",
           "description": {
@@ -804,7 +954,9 @@
         },
         {
           "name": "eight",
-          "displayName": "8 Subarctic/Arctic",
+          "displayName": {
+            "en": "8 Subarctic/Arctic"
+          },
           "enumValue": "8",
           "@id": "dtmi:com:syyclops:Building:eight;1",
           "description": {
@@ -823,6 +975,9 @@
       "enumValues": [
         {
           "enumValue": "Design",
+          "displayName": {
+            "en": "Design"
+          },
           "name": "Design",
           "@id": "dtmi:com:syyclops:Building:Design;1",
           "description": {
@@ -831,6 +986,9 @@
         },
         {
           "enumValue": "Construction",
+          "displayName": {
+            "en": "Construction"
+          },
           "name": "Construction",
           "@id": "dtmi:com:syyclops:Building:Construction;1",
           "description": {
@@ -839,6 +997,9 @@
         },
         {
           "enumValue": "Operational",
+          "displayName": {
+            "en": "Operational"
+          },
           "name": "Operational",
           "@id": "dtmi:com:syyclops:Building:Operational;1",
           "description": {

--- a/Ontology/Syyclops/Space/Outdoor Area/OutdoorArea.json
+++ b/Ontology/Syyclops/Space/Outdoor Area/OutdoorArea.json
@@ -146,6 +146,9 @@
       "enumValues": [
         {
           "enumValue": "Design",
+          "displayName": {
+            "en": "Design"
+          },
           "name": "Design",
           "@id": "dtmi:com:syyclops:OutdoorArea:Design;1",
           "description": {
@@ -154,6 +157,9 @@
         },
         {
           "enumValue": "Construction",
+          "displayName": {
+            "en": "Construction"
+          },
           "name": "Construction",
           "@id": "dtmi:com:syyclops:OutdoorArea:Construction;1",
           "description": {
@@ -162,6 +168,9 @@
         },
         {
           "enumValue": "Operational",
+          "displayName": {
+            "en": "Operational"
+          },
           "name": "Operational",
           "@id": "dtmi:com:syyclops:OutdoorArea:Operational;1",
           "description": {

--- a/Ontology/Syyclops/Space/Substructure/Substructure.json
+++ b/Ontology/Syyclops/Space/Substructure/Substructure.json
@@ -303,7 +303,9 @@
       "enumValues": [
         {
           "name": "oneA",
-          "displayName": "1A - Very Hot Humid",
+          "displayName": {
+            "en": "1A - Very Hot Humid"
+          },
           "enumValue": "1A",
           "@id": "dtmi:com:syyclops:Substructure:oneA;1",
           "description": {
@@ -312,7 +314,9 @@
         },
         {
           "name": "twoA",
-          "displayName": "2A Hot Humid",
+          "displayName": {
+            "en": "2A Hot Humid"
+          },
           "enumValue": "2A",
           "@id": "dtmi:com:syyclops:Substructure:twoA;1",
           "description": {
@@ -321,7 +325,9 @@
         },
         {
           "name": "twoB",
-          "displayName": "2B Hot Dry",
+          "displayName": {
+            "en": "2B Hot Dry"
+          },
           "enumValue": "2B",
           "@id": "dtmi:com:syyclops:Substructure:twoB;1",
           "description": {
@@ -330,7 +336,9 @@
         },
         {
           "name": "threeA",
-          "displayName": "3A Warm Humid",
+          "displayName": {
+            "en": "3A Warm Humid"
+          },
           "enumValue": "3A",
           "@id": "dtmi:com:syyclops:Substructure:threeA;1",
           "description": {
@@ -339,7 +347,9 @@
         },
         {
           "name": "threeB",
-          "displayName": "3B Warm Dry",
+          "displayName": {
+            "en": "3B Warm Dry"
+          },
           "enumValue": "3B",
           "@id": "dtmi:com:syyclops:Substructure:threeB;1",
           "description": {
@@ -348,7 +358,9 @@
         },
         {
           "name": "threeC",
-          "displayName": "3C Warm Marine",
+          "displayName": {
+            "en": "3C Warm Marine"
+          },
           "enumValue": "3C",
           "@id": "dtmi:com:syyclops:Substructure:threeC;1",
           "description": {
@@ -357,7 +369,9 @@
         },
         {
           "name": "fourA",
-          "displayName": "4A Mixed Humid",
+          "displayName": {
+            "en": "4A Mixed Humid"
+          },
           "enumValue": "4A",
           "@id": "dtmi:com:syyclops:Substructure:fourA;1",
           "description": {
@@ -366,7 +380,9 @@
         },
         {
           "name": "fourB",
-          "displayName": "4B Mixed Dry",
+          "displayName": {
+            "en": "4B Mixed Dry"
+          },
           "enumValue": "4B",
           "@id": "dtmi:com:syyclops:Substructure:fourB;1",
           "description": {
@@ -375,7 +391,9 @@
         },
         {
           "name": "fourC",
-          "displayName": "4C Mixed Marine",
+          "displayName": {
+            "en": "4C Mixed Marine"
+          },
           "enumValue": "4C",
           "@id": "dtmi:com:syyclops:Substructure:fourC;1",
           "description": {
@@ -384,7 +402,9 @@
         },
         {
           "name": "fiveA",
-          "displayName": "5A Cool Humid",
+          "displayName": {
+            "en": "5A Cool Humid"
+          },
           "enumValue": "5A",
           "@id": "dtmi:com:syyclops:Substructure:fiveA;1",
           "description": {
@@ -393,7 +413,9 @@
         },
         {
           "name": "fiveB",
-          "displayName": "5B Cool Dry",
+          "displayName": {
+            "en": "5B Cool Dry"
+          },
           "enumValue": "5B",
           "@id": "dtmi:com:syyclops:Substructure:fiveB;1",
           "description": {
@@ -402,7 +424,9 @@
         },
         {
           "name": "fiveC",
-          "displayName": "5C Cool Marine",
+          "displayName": {
+            "en": "5C Cool Marine"
+          },
           "enumValue": "5C",
           "@id": "dtmi:com:syyclops:Substructure:fiveC;1",
           "description": {
@@ -411,7 +435,9 @@
         },
         {
           "name": "sixA",
-          "displayName": "6A Cold Humid",
+          "displayName": {
+            "en": "6A Cold Humid"
+          },
           "enumValue": "6A",
           "@id": "dtmi:com:syyclops:Substructure:sixA;1",
           "description": {
@@ -420,7 +446,9 @@
         },
         {
           "name": "sixB",
-          "displayName": "6B Cold Dry",
+          "displayName": {
+            "en": "6B Cold Dry"
+          },
           "enumValue": "6B",
           "@id": "dtmi:com:syyclops:Substructure:sixB;1",
           "description": {
@@ -429,7 +457,9 @@
         },
         {
           "name": "seven",
-          "displayName": "7 Very Cold",
+          "displayName": {
+            "en": "7 Very Cold"
+          },
           "enumValue": "7",
           "@id": "dtmi:com:syyclops:Substructure:seven;1",
           "description": {
@@ -438,7 +468,9 @@
         },
         {
           "name": "eight",
-          "displayName": "8 Subarctic/Arctic",
+          "displayName": {
+            "en": "8 Subarctic/Arctic"
+          },
           "enumValue": "8",
           "@id": "dtmi:com:syyclops:Substructure:eight;1",
           "description": {
@@ -457,6 +489,9 @@
       "enumValues": [
         {
           "enumValue": "Design",
+          "displayName": {
+            "en": "Design"
+          },
           "name": "Design",
           "@id": "dtmi:com:syyclops:Substructure:Design;1",
           "description": {
@@ -465,6 +500,9 @@
         },
         {
           "enumValue": "Construction",
+          "displayName": {
+            "en": "Construction"
+          },
           "name": "Construction",
           "@id": "dtmi:com:syyclops:Substructure:Construction;1",
           "description": {
@@ -473,6 +511,9 @@
         },
         {
           "enumValue": "Operational",
+          "displayName": {
+            "en": "Operational"
+          },
           "name": "Operational",
           "@id": "dtmi:com:syyclops:Substructure:Operational;1",
           "description": {


### PR DESCRIPTION
## Overview

This PR makes every enum value in `Ontology/` carry `displayName.en`. The original scan estimated 319 missing values; a full re-scan found 492 across 55 files - all are covered here. After this change, all 966 enum values in the ontology have a localized display name.

Diff is large (+2340/-288) but mechanical: displayName additions and normalizations only. No `name`, `enumValue`, or `@id` is changed anywhere.

---

## Related Issues

- Relates to https://app.clickup.com/t/869e5dxv0 (seeds display_name_id into the DB and exposes it on the API)
