### PR TITLE
feat: add paidDate and amountPaid to UtilityBillEvent

### DIFF
--- a/Ontology/Syyclops/Event/Utility Bill/UtilityBillEvent.json
+++ b/Ontology/Syyclops/Event/Utility Bill/UtilityBillEvent.json
@@ -71,6 +71,32 @@
     },
     {
       "@type": "Property",
+      "description": {
+        "en": "Date when the bill was paid by the customer. Unset while the bill is outstanding; its presence is what settles the bill, so a bill past its dueDate counts as overdue only while this is absent."
+      },
+      "displayName": {
+        "en": "Paid Date"
+      },
+      "name": "paidDate",
+      "schema": "date",
+      "writable": true,
+      "@id": "dtmi:com:syyclops:UtilityBillEvent:paidDate;1"
+    },
+    {
+      "@type": "Property",
+      "description": {
+        "en": "Amount actually paid against this bill, which normally equals totalCharge. Recorded alongside paidDate for reconciliation; it does not by itself mark the bill settled, and a running balance across several part-payments is out of scope."
+      },
+      "displayName": {
+        "en": "Amount Paid"
+      },
+      "name": "amountPaid",
+      "writable": true,
+      "schema": "dtmi:com:syyclops:UtilityBillEventCharges;1",
+      "@id": "dtmi:com:syyclops:UtilityBillEvent:amountPaid;1"
+    },
+    {
+      "@type": "Property",
       "displayName": {
         "en": "Total Charge"
       },


### PR DESCRIPTION
Utility bills had no way to record payment, so every bill past its dueDate read as overdue forever with nothing to distinguish a settled bill from an outstanding one.

paidDate (date) settles the bill: its absence is what marks a bill unpaid, so consumers derive overdue as "past dueDate and no paidDate". Modelling it as a nullable date rather than a boolean records when, not just whether, and needs no backfill for existing bills.

amountPaid reuses the existing UtilityBillEventCharges object schema that totalCharge already uses, so a payment carries its currency rather than being a bare number. It is recorded for reconciliation and does not itself settle the bill; a running balance across several part-payments is out of scope, and would be modelled as its own entity rather than more fields here.

Both are declared on the base interface, so all seven concrete bill types (electricity, natural gas, potable water, reclaimed water, internet, garbage/waste, generator fuel) inherit them. Purely additive — no existing property or schema changes.