### PR TITLE
feat: add BuildingType enum and retype Building.type

### DIFF
--- a/Ontology/Syyclops/Space/Building/Building.json
+++ b/Ontology/Syyclops/Space/Building/Building.json
@@ -102,7 +102,7 @@
         "en": "Type"
       },
       "writable": true,
-      "schema": "string",
+      "schema": "dtmi:com:syyclops:BuildingType;1",
       "@id": "dtmi:com:syyclops:Building:type;1",
       "description": {
         "en": "The type property categorizes the building based on its primary function or usage."
@@ -322,6 +322,203 @@
     }
   ],
   "schemas": [
+    {
+      "@id": "dtmi:com:syyclops:BuildingType;1",
+      "@type": "Enum",
+      "valueSchema": "string",
+      "displayName": {
+        "en": "Building Type"
+      },
+      "enumValues": [
+        {
+          "enumValue": "Residential",
+          "displayName": {
+            "en": "Residential"
+          },
+          "name": "residential",
+          "@id": "dtmi:com:syyclops:BuildingType:residential;1",
+          "description": {
+            "en": "Single-family, multi-family, dormitory/residence hall, or senior living."
+          }
+        },
+        {
+          "enumValue": "K-12 School",
+          "displayName": {
+            "en": "K-12 School"
+          },
+          "name": "k12School",
+          "@id": "dtmi:com:syyclops:BuildingType:k12School;1",
+          "description": {
+            "en": "Primary and secondary education facilities serving kindergarten through 12th grade."
+          }
+        },
+        {
+          "enumValue": "Higher Education",
+          "displayName": {
+            "en": "Higher Education"
+          },
+          "name": "higherEducation",
+          "@id": "dtmi:com:syyclops:BuildingType:higherEducation;1",
+          "description": {
+            "en": "Colleges, universities, and other post-secondary education facilities."
+          }
+        },
+        {
+          "enumValue": "Research / Lab",
+          "displayName": {
+            "en": "Research / Lab"
+          },
+          "name": "researchLab",
+          "@id": "dtmi:com:syyclops:BuildingType:researchLab;1",
+          "description": {
+            "en": "Laboratory and research facilities."
+          }
+        },
+        {
+          "enumValue": "Office / Administrative",
+          "displayName": {
+            "en": "Office / Administrative"
+          },
+          "name": "officeAdministrative",
+          "@id": "dtmi:com:syyclops:BuildingType:officeAdministrative;1",
+          "description": {
+            "en": "Office and administrative workplaces."
+          }
+        },
+        {
+          "enumValue": "Healthcare",
+          "displayName": {
+            "en": "Healthcare"
+          },
+          "name": "healthcare",
+          "@id": "dtmi:com:syyclops:BuildingType:healthcare;1",
+          "description": {
+            "en": "Hospital, outpatient/clinic, or long-term care."
+          }
+        },
+        {
+          "enumValue": "Assembly",
+          "displayName": {
+            "en": "Assembly"
+          },
+          "name": "assembly",
+          "@id": "dtmi:com:syyclops:BuildingType:assembly;1",
+          "description": {
+            "en": "Auditorium, theater, convention center, place of worship, or museum."
+          }
+        },
+        {
+          "enumValue": "Recreational / Athletic",
+          "displayName": {
+            "en": "Recreational / Athletic"
+          },
+          "name": "recreationalAthletic",
+          "@id": "dtmi:com:syyclops:BuildingType:recreationalAthletic;1",
+          "description": {
+            "en": "Gymnasium, arena, natatorium, or recreation center."
+          }
+        },
+        {
+          "enumValue": "Mercantile / Retail",
+          "displayName": {
+            "en": "Mercantile / Retail"
+          },
+          "name": "mercantileRetail",
+          "@id": "dtmi:com:syyclops:BuildingType:mercantileRetail;1",
+          "description": {
+            "en": "Retail and mercantile facilities."
+          }
+        },
+        {
+          "enumValue": "Hospitality",
+          "displayName": {
+            "en": "Hospitality"
+          },
+          "name": "hospitality",
+          "@id": "dtmi:com:syyclops:BuildingType:hospitality;1",
+          "description": {
+            "en": "Hotel, restaurant, or food service."
+          }
+        },
+        {
+          "enumValue": "Industrial / Manufacturing",
+          "displayName": {
+            "en": "Industrial / Manufacturing"
+          },
+          "name": "industrialManufacturing",
+          "@id": "dtmi:com:syyclops:BuildingType:industrialManufacturing;1",
+          "description": {
+            "en": "Industrial and manufacturing facilities."
+          }
+        },
+        {
+          "enumValue": "Storage / Warehouse",
+          "displayName": {
+            "en": "Storage / Warehouse"
+          },
+          "name": "storageWarehouse",
+          "@id": "dtmi:com:syyclops:BuildingType:storageWarehouse;1",
+          "description": {
+            "en": "Storage and warehouse facilities."
+          }
+        },
+        {
+          "enumValue": "Transportation",
+          "displayName": {
+            "en": "Transportation"
+          },
+          "name": "transportation",
+          "@id": "dtmi:com:syyclops:BuildingType:transportation;1",
+          "description": {
+            "en": "Transit station, airport terminal, or parking structure."
+          }
+        },
+        {
+          "enumValue": "Utility / Infrastructure",
+          "displayName": {
+            "en": "Utility / Infrastructure"
+          },
+          "name": "utilityInfrastructure",
+          "@id": "dtmi:com:syyclops:BuildingType:utilityInfrastructure;1",
+          "description": {
+            "en": "Central plant, water/wastewater treatment, or power generation."
+          }
+        },
+        {
+          "enumValue": "Public Safety / Institutional",
+          "displayName": {
+            "en": "Public Safety / Institutional"
+          },
+          "name": "publicSafetyInstitutional",
+          "@id": "dtmi:com:syyclops:BuildingType:publicSafetyInstitutional;1",
+          "description": {
+            "en": "Fire station, police, courthouse, correctional/detention, or library."
+          }
+        },
+        {
+          "enumValue": "Data Center / Telecommunications",
+          "displayName": {
+            "en": "Data Center / Telecommunications"
+          },
+          "name": "dataCenter",
+          "@id": "dtmi:com:syyclops:BuildingType:dataCenter;1",
+          "description": {
+            "en": "Data center and telecommunications facilities."
+          }
+        },
+        {
+          "enumValue": "Mixed-Use",
+          "displayName": {
+            "en": "Mixed-Use"
+          },
+          "name": "mixedUse",
+          "@id": "dtmi:com:syyclops:BuildingType:mixedUse;1",
+          "description": {
+            "en": "A building combining two or more primary uses."
+          }
+        }
+      ]
+    },
     {
       "@id": "dtmi:com:syyclops:BuildingCBECSBuildingType;1",
       "@type": "Enum",


### PR DESCRIPTION
## Why

Syyclops' task library is organised into folders, some of which are vertical — `K-12 Schools`, `Healthcare / Hospitals`, `Data Centers / Mission Critical`, `Retail & Restaurant`. Nothing in the ontology said what *kind* of building a `Building` is, so every customer saw every vertical's tasks. COBie also carries a building-type field with no counterpart here.

`Building` already had a `type` property described as "categorizes the building based on its primary function or usage" — exactly this concept — but typed as a free string, so it was unusable as a controlled vocabulary and unused in practice.

## What changes

- Adds `dtmi:com:syyclops:BuildingType;1`, a string-valued `Enum` with 17 members.
- Changes `dtmi:com:syyclops:Building:type;1` from `"schema": "string"` to `"schema": "dtmi:com:syyclops:BuildingType;1"`.

The property keeps its DTMI, name, displayName and description. Only the schema tightens.

```
- "schema": "string",
+ "schema": "dtmi:com:syyclops:BuildingType;1",
```

## The 17 members

Residential · K-12 School · Higher Education · Research / Lab · Office / Administrative · Healthcare · Assembly · Recreational / Athletic · Mercantile / Retail · Hospitality · Industrial / Manufacturing · Storage / Warehouse · Transportation · Utility / Infrastructure · Public Safety / Institutional · Data Center / Telecommunications · Mixed-Use

Every member carries a `displayName` and a `description`. The descriptions hold the sub-categories from the source request — `Residential` is described as "Single-family, multi-family, dormitory/residence hall, or senior living" — so consumers can render them as helper text without hardcoding labels.

Declaration order is meaningful: the generator derives `position` from the array index, and Syyclops sorts dropdowns on it.

## Two decisions worth a look

**Member DTMIs are namespaced under `BuildingType:`, not `Building:`.** The CBECS and ENERGY STAR enums on this same interface already occupy `dtmi:com:syyclops:Building:Office;1`, `:Hospital;1`, `:DataCenter;1`, `:MultifamilyHousing;1` and others. Reusing that namespace would have collided on at least three members.

**Education was added, though it wasn't in the source list.** The original proposal had 15 types with no education entry, but `K-12 Schools` (14 tasks) and `Higher Education` (8 tasks) are two of the largest folders in the task library, and K-12 was the leading example in the request. Without them those folders were unreachable. They are separate members rather than one combined `Education` so a K-12 school doesn't inherit higher-ed tasks.

## Objection you might raise

Tightening the schema of an existing DTMI is, strictly, a breaking change to `Building;1` — a purist would bump the property or the interface to `;2`. I didn't, because `Building:type;1` has no readers or writers in the Syyclops codebase and no values in any database we control, so the "break" is theoretical. If you'd rather not mutate a shipped property, the alternative is a new `buildingType` property with a fresh DTMI, leaving `type` orphaned as dead weight; say the word and I'll switch it.

## Downstream

`Syyclops/syyclops-v3` has a branch waiting on this that bumps the submodule pointer, regenerates the SDK, and ships the matching data migration. `validate-ontology-drift.sh` requires the pinned commit to be an ancestor of this repo's `main`, so this merges first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
